### PR TITLE
fix: harden User.__init__ against missing legacy fields (0.1.4)

### DIFF
--- a/docs/TECHNICAL.md
+++ b/docs/TECHNICAL.md
@@ -1010,6 +1010,23 @@ uv cache clean
 pip install --upgrade twikit-mcp
 ```
 
+### 报错 `KeyError: 'xxx'`（pinned_tweet_ids_str、withheld_in_countries、entities 等）？
+
+这是 `User` 对象解析时 `legacy.*` 字段缺失的问题。X 的 GraphQL 响应并不保证所有 legacy 字段都存在（例如没 pinned tweet 的账号不会返回 `pinned_tweet_ids_str`），上游 twikit 硬索引这些字段会直接抛 KeyError。
+
+- **0.1.3** 修了 `legacy.entities.description.urls` 和 `legacy.withheld_in_countries`
+- **0.1.4** 全面防御化了 `User.__init__` 里所有 `legacy.*` 字段
+
+升级到 `>=0.1.4` 即可：
+
+```bash
+uv tool upgrade twikit-mcp     # uv tool
+uv cache clean                  # uvx（下次自动取新版）
+pip install --upgrade twikit-mcp
+```
+
+详见 [VENDORING.md](VENDORING.md#本地-patch-清单)。
+
 ### 想让其他 Claude 实例也能用？
 
 MCP 注册在 `~/.claude.json` 的用户级配置中（`-s user`），所以**同一台机器上所有 Claude Code 会话自动共享**。不需要额外配置。

--- a/docs/VENDORING.md
+++ b/docs/VENDORING.md
@@ -34,6 +34,43 @@ PyPI 上的 twikit 2.3.3 有两个已知 bug：
 
 ---
 
+## 本地 patch 清单
+
+除了从 PR#412 引入的两个修复外，vendored 代码还包含我们自己发现并修复的 bug。
+
+| 版本 | 文件 | 修复内容 |
+|------|------|---------|
+| 0.1.3 | `_vendor/twikit/user.py` | `User.__init__` 容忍 `legacy.entities.description.urls` 和 `legacy.withheld_in_countries` 缺失 |
+| 0.1.4 | `_vendor/twikit/user.py` | `User.__init__` 全面防御化，所有 `legacy.*` 字段改 `.get()` 带默认值 |
+
+### 为什么要防御化 `User.__init__`
+
+**问题：** X 的 GraphQL 响应并不保证 `legacy.*` 下的所有字段都存在。实际观察到的缺失场景：
+
+- 账号没 pinned tweet → `pinned_tweet_ids_str` 不返回（触发 `@ClaudeDevs` 的 bug）
+- 账号没受地区限制 → `withheld_in_countries` 不返回（触发 `@elonmusk` 的 bug）
+- 账号 profile description 为空 → `entities.description.urls` 不返回
+- 新建/冻结/不活跃账号 → counts、flags 等字段可能大面积缺失
+
+上游 twikit 在 `__init__` 里用 `legacy["key"]` 严格索引，任一字段缺失就抛 `KeyError`，连锁导致所有依赖 `User` 对象的工具（`get_user_tweets`、`client.user()` 等）全部不可用。
+
+**解决方式：** `__init__` 里所有 `legacy[...]` 改为 `.get(..., 默认值)`，默认值按类型：
+
+| 类型 | 默认 |
+|------|------|
+| 计数类（`*_count`） | `0` |
+| 布尔标志 | `False` |
+| 列表类（`*_ids`、`withheld_in_countries`） | `[]` |
+| 字符串类（`name`、`location`、`description`） | `""` |
+| 可选 URL（`profile_banner_url`、`url`） | `None`（保留原行为） |
+| `translator_type` | `"none"` |
+
+外层 `data["rest_id"]` 保留严格访问 —— `rest_id` 是 X API 的核心标识，缺失才是真异常。
+
+**回归测试：** `tests/test_user_parsing.py` 对每个可缺失字段做单独的参数化测试，外加「整个 `legacy` 为空 dict」的兜底用例，总 29 个。
+
+---
+
 ## PR#412 修复内容
 
 PR#412 包含 5 个 commit，改了 2 个文件（忽略 .gitignore）：

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "twikit-mcp"
-version = "0.1.3"
+version = "0.1.4"
 description = "Twitter/X MCP server powered by twikit — no API key needed, free forever"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_user_parsing.py
+++ b/tests/test_user_parsing.py
@@ -94,3 +94,68 @@ def test_user_parses_when_both_missing(entities, include_withheld):
     user = User(client=None, data=data)
     assert user.description_urls == []
     assert user.withheld_in_countries == []
+
+
+# ── Phase 2: full defensive parsing ───────────────────
+#
+# X's GraphQL may omit almost any legacy.* field depending on the account's
+# state (no pinned tweet → no pinned_tweet_ids_str; fresh/suspended accounts
+# may drop counts, flags, etc.). User.__init__ must not raise KeyError when
+# any of these are absent — parse what's present, default the rest.
+
+
+def test_user_parses_when_legacy_is_empty():
+    """legacy = {} must not raise — every non-essential field defaults."""
+    data = {
+        "rest_id": "1",
+        "is_blue_verified": False,
+        "legacy": {},
+    }
+    user = User(client=None, data=data)
+    # Counts default to 0
+    assert user.followers_count == 0
+    assert user.statuses_count == 0
+    assert user.media_count == 0
+    # Flags default to False
+    assert user.verified is False
+    assert user.can_dm is False
+    # Lists default to []
+    assert user.pinned_tweet_ids == []
+    assert user.description_urls == []
+    assert user.withheld_in_countries == []
+
+
+@pytest.mark.parametrize(
+    "drop_field",
+    [
+        "pinned_tweet_ids_str",
+        "verified",
+        "followers_count",
+        "friends_count",
+        "favourites_count",
+        "listed_count",
+        "media_count",
+        "statuses_count",
+        "fast_followers_count",
+        "normal_followers_count",
+        "can_dm",
+        "can_media_tag",
+        "want_retweets",
+        "default_profile",
+        "default_profile_image",
+        "has_custom_timelines",
+        "possibly_sensitive",
+        "is_translator",
+        "translator_type",
+        "location",
+        "description",
+        "created_at",
+        "profile_image_url_https",
+    ],
+)
+def test_user_parses_when_single_legacy_field_missing(drop_field):
+    """Any individual legacy.* field may be absent — User must still construct."""
+    data = _minimal_user_data()
+    del data["legacy"][drop_field]
+    # Must not raise
+    User(client=None, data=data)

--- a/twitter_mcp/_vendor/twikit/user.py
+++ b/twitter_mcp/_vendor/twikit/user.py
@@ -88,41 +88,40 @@ class User:
 
     def __init__(self, client: Client, data: dict) -> None:
         self._client = client
-        legacy = data["legacy"]
+        legacy = data.get("legacy", {})
+        entities = legacy.get("entities", {})
 
         self.id: str = data["rest_id"]
-        self.created_at: str = legacy["created_at"]
-        self.name: str = legacy["name"]
-        self.screen_name: str = legacy["screen_name"]
-        self.profile_image_url: str = legacy["profile_image_url_https"]
+        self.created_at: str = legacy.get("created_at", "")
+        self.name: str = legacy.get("name", "")
+        self.screen_name: str = legacy.get("screen_name", "")
+        self.profile_image_url: str = legacy.get("profile_image_url_https", "")
         self.profile_banner_url: str = legacy.get("profile_banner_url")
         self.url: str = legacy.get("url")
-        self.location: str = legacy["location"]
-        self.description: str = legacy["description"]
-        self.description_urls: list = (
-            legacy.get("entities", {}).get("description", {}).get("urls", [])
-        )
-        self.urls: list = legacy["entities"].get("url", {}).get("urls")
-        self.pinned_tweet_ids: list[str] = legacy["pinned_tweet_ids_str"]
-        self.is_blue_verified: bool = data["is_blue_verified"]
-        self.verified: bool = legacy["verified"]
-        self.possibly_sensitive: bool = legacy["possibly_sensitive"]
-        self.can_dm: bool = legacy["can_dm"]
-        self.can_media_tag: bool = legacy["can_media_tag"]
-        self.want_retweets: bool = legacy["want_retweets"]
-        self.default_profile: bool = legacy["default_profile"]
-        self.default_profile_image: bool = legacy["default_profile_image"]
-        self.has_custom_timelines: bool = legacy["has_custom_timelines"]
-        self.followers_count: int = legacy["followers_count"]
-        self.fast_followers_count: int = legacy["fast_followers_count"]
-        self.normal_followers_count: int = legacy["normal_followers_count"]
-        self.following_count: int = legacy["friends_count"]
-        self.favourites_count: int = legacy["favourites_count"]
-        self.listed_count: int = legacy["listed_count"]
-        self.media_count = legacy["media_count"]
-        self.statuses_count: int = legacy["statuses_count"]
-        self.is_translator: bool = legacy["is_translator"]
-        self.translator_type: str = legacy["translator_type"]
+        self.location: str = legacy.get("location", "")
+        self.description: str = legacy.get("description", "")
+        self.description_urls: list = entities.get("description", {}).get("urls", [])
+        self.urls: list = entities.get("url", {}).get("urls", [])
+        self.pinned_tweet_ids: list[str] = legacy.get("pinned_tweet_ids_str", [])
+        self.is_blue_verified: bool = data.get("is_blue_verified", False)
+        self.verified: bool = legacy.get("verified", False)
+        self.possibly_sensitive: bool = legacy.get("possibly_sensitive", False)
+        self.can_dm: bool = legacy.get("can_dm", False)
+        self.can_media_tag: bool = legacy.get("can_media_tag", False)
+        self.want_retweets: bool = legacy.get("want_retweets", False)
+        self.default_profile: bool = legacy.get("default_profile", False)
+        self.default_profile_image: bool = legacy.get("default_profile_image", False)
+        self.has_custom_timelines: bool = legacy.get("has_custom_timelines", False)
+        self.followers_count: int = legacy.get("followers_count", 0)
+        self.fast_followers_count: int = legacy.get("fast_followers_count", 0)
+        self.normal_followers_count: int = legacy.get("normal_followers_count", 0)
+        self.following_count: int = legacy.get("friends_count", 0)
+        self.favourites_count: int = legacy.get("favourites_count", 0)
+        self.listed_count: int = legacy.get("listed_count", 0)
+        self.media_count = legacy.get("media_count", 0)
+        self.statuses_count: int = legacy.get("statuses_count", 0)
+        self.is_translator: bool = legacy.get("is_translator", False)
+        self.translator_type: str = legacy.get("translator_type", "none")
         self.withheld_in_countries: list[str] = legacy.get("withheld_in_countries", [])
         self.protected: bool = legacy.get("protected", False)
 

--- a/uv.lock
+++ b/uv.lock
@@ -1169,7 +1169,7 @@ wheels = [
 
 [[package]]
 name = "twikit-mcp"
-version = "0.1.2"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Summary

0.1.3 only patched two specific fields (`entities.description.urls`, `withheld_in_countries`) — the ones that happened to crash first when I tested with `@elonmusk`. Five minutes after release, `@ClaudeDevs` hit `KeyError: 'pinned_tweet_ids_str'`.

Root cause: X's GraphQL responses are unreliable across the **entire** `legacy.*` namespace, not just those two fields. Accounts without a pinned tweet drop `pinned_tweet_ids_str`, inactive/fresh accounts may drop counts and flags, profiles with empty bios drop `entities.description`, etc. Upstream twikit strictly indexes every field.

This PR rewrites `User.__init__` so the whole `legacy` dict is treated as optional — parse what's present, default the rest.

## Changes

- Every `legacy[...]` → `.get(..., default)` with per-type defaults:
  - Counts → `0`
  - Flags → `False`
  - Lists → `[]`
  - Strings → `""`
  - Optional URLs → `None` (preserve original behavior)
  - `translator_type` → `"none"`
- `legacy` itself defaults to `{}` — even a user payload with zero legacy data constructs.
- `data["rest_id"]` kept strict (the only truly required field).

## Test plan

- [x] Red: added 23 parametrized drop-one-field cases + 1 empty-legacy case — all failed before the fix.
- [x] Green: all 29 parsing tests + 60 total pass.
- [x] Lint/format clean.
- [x] Live: `get_user_tweets("ClaudeDevs", count=5)` returns real tweets (previously crashed).
- [x] Live: `get_user_tweets("elonmusk")` still works (0.1.3 regression check).

## Docs

- `docs/VENDORING.md`: new "本地 patch 清单" section documenting the instability pattern and both 0.1.3/0.1.4 patches.
- `docs/TECHNICAL.md`: new troubleshooting entry for `KeyError: 'xxx'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)