### PR TITLE
ci: auto-publish from main push (no manual tag needed)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,10 +4,45 @@ on:
   push:
     tags:
       - "v*"
+    branches:
+      - main
 
 jobs:
+  detect:
+    name: Detect publishable version
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.detect.outputs.tag }}
+      should_publish: ${{ steps.detect.outputs.should_publish }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - id: detect
+        shell: bash
+        run: |
+          set -e
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          v=$(grep -E '^version' pyproject.toml | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
+          tag="v$v"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          if git rev-parse --verify "refs/tags/$tag" >/dev/null 2>&1; then
+            echo "Tag $tag already exists; nothing to publish"
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Tag $tag missing; will publish"
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
   test:
     name: Run tests before publish
+    needs: detect
+    if: needs.detect.outputs.should_publish == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -29,7 +64,8 @@ jobs:
 
   publish:
     name: Build & Publish
-    needs: test
+    needs: [detect, test]
+    if: needs.detect.outputs.should_publish == 'true'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -48,7 +84,8 @@ jobs:
 
   release:
     name: Create GitHub Release
-    needs: publish
+    needs: [detect, publish]
+    if: needs.detect.outputs.should_publish == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -60,8 +97,8 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref_name }}
-          name: ${{ github.ref_name }}
+          tag_name: ${{ needs.detect.outputs.tag }}
+          name: ${{ needs.detect.outputs.tag }}
           generate_release_notes: true
           draft: false
           prerelease: false


### PR DESCRIPTION
## Why

合 PR #5 之后,0.1.7 卡在 main 没人推 tag — 这个 assistant 没有 git tag push 的能力,GitHub MCP 也没有 `create_tag` / `create_release` / `dispatch_workflow` 写工具,会话沙盒级别堵死,加权限也绕不过去。

这个 PR 把 `publish.yml` 改造成"merge 到 main 就发布",彻底去掉手动打 tag 这一步。

## What

`publish.yml` 多一个 `push: branches: main` 触发,加一个 `detect` job:
- 如果是 `refs/tags/v*` push → 老路径,沿用 `github.ref_name`
- 如果是 main push → 读 `pyproject.toml` 的 version,推算出 `vX.Y.Z` tag。该 tag 不存在 → `should_publish=true`;已存在 → 全 skip(幂等)

`test` / `publish` / `release` 都加 `if: needs.detect.outputs.should_publish == 'true'`。`release` job 改用 `needs.detect.outputs.tag` 而不是 `github.ref_name`,这样从 main 触发时也能拿到正确的 tag 名。`softprops/action-gh-release@v2` 在 tag 不存在时会自动在 checkout SHA 处建 tag。

## 直接效果

合并这个 PR → main 收到一个新 push → publish.yml 触发:
1. detect: pyproject.toml 是 0.1.7,v0.1.7 tag 不存在 → 出版
2. test: ruff + pytest --cov-fail-under=95
3. publish: uv build + Trusted Publisher 发到 PyPI
4. release: 创建 v0.1.7 tag(softprops 自动建)+ 创建 GitHub Release

PyPI 上出现 0.1.7,Releases 里出现 v0.1.7 — **不需要任何本地 / UI 操作**。

未来发版工作流也变了:开个 PR bump version → 合并 → 完事。

## Test plan

- [ ] 合并后看 Actions 页面 detect 是否报 `should_publish=true / tag=v0.1.7`
- [ ] PyPI 上出现 0.1.7
- [ ] Releases 出现 v0.1.7,描述由 `generate_release_notes` 自动填
- [ ] 第二次合并(没改 version)时 detect 应 `should_publish=false`,workflow 早 skip

https://claude.ai/code/session_01YZ5NXtFwvf3yybuRVSzvPY

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZ5NXtFwvf3yybuRVSzvPY)_