### PR TITLE
fix: unpack tuple from twikit gql transport + add live-smoke workflow (closes #12)

### DIFF
--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -1,0 +1,95 @@
+name: Live integration smoke test
+
+# Verifies get_article actually pulls a real X Article body.
+# Uses a burner X account's cookies stored as repo secrets:
+#   TWITTER_CT0
+#   TWITTER_AUTH_TOKEN
+#
+# Never run against forks — secrets aren't exposed there anyway, and the
+# `if: github.repository == 'tangivis/twitter-mcp'` guard makes that explicit.
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    # Mondays 12:00 UTC — weekly canary.
+    - cron: "0 12 * * 1"
+  push:
+    branches: [main]
+    paths:
+      - "twitter_mcp/**"
+      - ".github/workflows/live-smoke.yml"
+
+# Cancel an in-flight run if a new push lands; only one live-smoke per ref.
+concurrency:
+  group: live-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  smoke:
+    name: get_article live fetch
+    if: github.repository == 'tangivis/twitter-mcp'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Mask cookies in all subsequent logs
+        env:
+          CT0: ${{ secrets.TWITTER_CT0 }}
+          AUTH: ${{ secrets.TWITTER_AUTH_TOKEN }}
+        run: |
+          # ::add-mask:: tells the runner to redact this string from any
+          # later log line. Safety net in case anything echoes a header
+          # or the cookies file.
+          echo "::add-mask::$CT0"
+          echo "::add-mask::$AUTH"
+
+      - name: Write cookies file
+        env:
+          CT0: ${{ secrets.TWITTER_CT0 }}
+          AUTH: ${{ secrets.TWITTER_AUTH_TOKEN }}
+        run: |
+          if [ -z "$CT0" ] || [ -z "$AUTH" ]; then
+            echo "::error::TWITTER_CT0 / TWITTER_AUTH_TOKEN secrets are not set."
+            exit 1
+          fi
+          mkdir -p "$HOME/.config/twitter-mcp"
+          # Use jq -n so the values never appear on a shell command line.
+          jq -n --arg c "$CT0" --arg a "$AUTH" \
+            '{ct0:$c, auth_token:$a}' \
+            > "$HOME/.config/twitter-mcp/cookies.json"
+          chmod 600 "$HOME/.config/twitter-mcp/cookies.json"
+
+      - name: Install dependencies
+        run: uv sync --group dev
+
+      - name: Smoke get_article against a known public article
+        # Jaden_riku's "2026年，日本国运的分水岭" — verified at the HTTP layer
+        # in issue #10. If the body comes back populated, the two-hop flow
+        # plus the issue #12 tuple unpack are both working.
+        run: |
+          uv run python - <<'PY'
+          import asyncio, json
+          from twitter_mcp.server import get_article
+
+          ARTICLE_ID = "2048420352397864960"
+          out = json.loads(asyncio.run(get_article(ARTICLE_ID)))
+
+          title = out.get("title") or ""
+          body  = out.get("plain_text") or ""
+          media = out.get("media_entities") or []
+
+          print(f"title  = {title!r}")
+          print(f"body   = {len(body)} chars")
+          print(f"media  = {len(media)} entries")
+
+          assert title,             "no title in article payload"
+          assert len(body) > 1000,  f"plain_text suspiciously short: {len(body)} chars"
+          PY

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "twikit-mcp"
-version = "0.1.9"
+version = "0.1.10"
 description = "Twitter/X MCP server powered by twikit — no API key needed, free forever"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_articles.py
+++ b/tests/test_articles.py
@@ -164,71 +164,85 @@ async def test_get_article_preview_raises_when_no_article(monkeypatch):
 # ── get_article: two-hop reader flow (issue #10) ─────
 
 
+# twikit's gql_get / tweet_result_by_rest_id return `tuple[dict, Response]`,
+# not a bare dict (issue #12). Fixtures wrap mocked payloads accordingly so
+# tests exercise the actual transport contract.
+def _as_twikit_return(payload):
+    """Wrap a mocked dict in the (response_json, raw_response) tuple twikit returns."""
+    return (payload, MagicMock(name="raw_response"))
+
+
 def _redirect_response(tweet_id="2048697545527009367"):
     """Hop-1 response: ArticleRedirectScreenQuery resolves article → tweet."""
-    return {
-        "data": {
-            "article_result_by_rest_id": {
-                "result": {
-                    "__typename": "ArticleEntity",
-                    "metadata": {
-                        "author_results": {
-                            "result": {"core": {"screen_name": "Jaden_riku"}}
+    return _as_twikit_return(
+        {
+            "data": {
+                "article_result_by_rest_id": {
+                    "result": {
+                        "__typename": "ArticleEntity",
+                        "metadata": {
+                            "author_results": {
+                                "result": {"core": {"screen_name": "Jaden_riku"}}
+                            },
+                            "tweet_results": {"rest_id": tweet_id},
                         },
-                        "tweet_results": {"rest_id": tweet_id},
-                    },
+                    }
                 }
             }
         }
-    }
+    )
 
 
 def _redirect_response_empty():
     """Hop-1 response when the article isn't visible (deleted / private / wrong namespace)."""
-    return {"data": {"article_result_by_rest_id": {"result": {}}}}
+    return _as_twikit_return({"data": {"article_result_by_rest_id": {"result": {}}}})
 
 
 def _tweet_response_with_article(plain_text="full body 13984 chars goes here"):
     """Hop-2 response: TweetResultByRestId with the article payload nested."""
-    return {
-        "data": {
-            "tweetResult": {
-                "result": {
-                    "__typename": "Tweet",
-                    "rest_id": "2048697545527009367",
-                    "article": {
-                        "article_results": {
-                            "result": {
-                                "title": "2026年，日本国运的分水岭",
-                                "preview_text": "preview…",
-                                "plain_text": plain_text,
-                                "content_state": {"blocks": []},
-                                "cover_media": {
-                                    "media_info": {
-                                        "original_img_url": (
-                                            "https://pbs.twimg.com/media/HG13LzYbkAAI7Ro.jpg"
-                                        )
-                                    }
-                                },
-                                "media_entities": [{} for _ in range(10)],
+    return _as_twikit_return(
+        {
+            "data": {
+                "tweetResult": {
+                    "result": {
+                        "__typename": "Tweet",
+                        "rest_id": "2048697545527009367",
+                        "article": {
+                            "article_results": {
+                                "result": {
+                                    "title": "2026年，日本国运的分水岭",
+                                    "preview_text": "preview…",
+                                    "plain_text": plain_text,
+                                    "content_state": {"blocks": []},
+                                    "cover_media": {
+                                        "media_info": {
+                                            "original_img_url": (
+                                                "https://pbs.twimg.com/media/HG13LzYbkAAI7Ro.jpg"
+                                            )
+                                        }
+                                    },
+                                    "media_entities": [{} for _ in range(10)],
+                                }
                             }
-                        }
-                    },
+                        },
+                    }
                 }
             }
         }
-    }
+    )
 
 
 def _tweet_response_no_article():
     """Hop-2 response where the tweet exists but has no article payload."""
-    return {
-        "data": {
-            "tweetResult": {
-                "result": {"__typename": "Tweet", "rest_id": "2048697545527009367"}
+    return _as_twikit_return(
+        {
+            "data": {
+                "tweetResult": {
+                    "result": {"__typename": "Tweet", "rest_id": "2048697545527009367"}
+                }
             }
         }
-    }
+    )
 
 
 @pytest.fixture
@@ -419,11 +433,11 @@ async def test_get_article_ignores_stale_env_var(monkeypatch, fake_two_hop_clien
     assert "STALE_HASH_FROM_USER_ENV" not in args[0]
 
 
-async def test_get_article_raises_when_redirect_is_none(
+async def test_get_article_raises_when_redirect_body_is_none(
     monkeypatch, fake_two_hop_client
 ):
-    """A None redirect response (network glitch / unexpected shape) → ToolError."""
-    fake_two_hop_client.gql_get.return_value = None
+    """A None redirect body (network glitch / malformed) → ToolError, no crash."""
+    fake_two_hop_client.gql_get.return_value = _as_twikit_return(None)
     with pytest.raises(ToolError):
         await server.get_article("2048420352397864960")
     fake_two_hop_client.tweet_result.assert_not_called()
@@ -433,17 +447,40 @@ async def test_get_article_raises_when_redirect_missing_data_key(
     monkeypatch, fake_two_hop_client
 ):
     """Redirect response without a `data` key → ToolError, no traceback."""
-    fake_two_hop_client.gql_get.return_value = {"errors": [{"message": "rate limit"}]}
+    fake_two_hop_client.gql_get.return_value = _as_twikit_return(
+        {"errors": [{"message": "rate limit"}]}
+    )
     with pytest.raises(ToolError):
         await server.get_article("2048420352397864960")
     fake_two_hop_client.tweet_result.assert_not_called()
 
 
-async def test_get_article_raises_when_hop2_is_none(monkeypatch, fake_two_hop_client):
-    """A None tweet response (twikit transient failure) → ToolError, not crash."""
-    fake_two_hop_client.tweet_result.return_value = None
+async def test_get_article_raises_when_hop2_body_is_none(
+    monkeypatch, fake_two_hop_client
+):
+    """A None tweet body (twikit transient failure) → ToolError, not crash."""
+    fake_two_hop_client.tweet_result.return_value = _as_twikit_return(None)
     with pytest.raises(ToolError):
         await server.get_article("2048420352397864960")
+
+
+async def test_get_article_unpacks_tuple_returned_by_twikit(
+    monkeypatch, fake_two_hop_client
+):
+    """Issue #12 regression: gql_get / tweet_result_by_rest_id return
+    `tuple[dict, Response]`, not a dict.
+
+    The fix in 0.1.10 unpacks both with `body, _ = await ...`. If a
+    future refactor removes the unpack, the production code would call
+    `.get()` on a tuple and crash with the exact bug from issue #12:
+    `'tuple' object has no attribute 'get'`. This test pins the contract.
+    """
+    # Both fixtures already return tuples (per the issue).
+    out = await server.get_article("2048420352397864960")
+    payload = json.loads(out)
+    # The article body must have flowed through both unpacks correctly.
+    assert payload["title"] == "2026年，日本国运的分水岭"
+    assert payload["plain_text"] == "full body 13984 chars goes here"
 
 
 async def test_get_article_preserves_full_article_payload(

--- a/tests/test_articles.py
+++ b/tests/test_articles.py
@@ -363,13 +363,15 @@ async def test_get_article_raises_when_redirect_missing_tweet_id(
     monkeypatch, fake_two_hop_client
 ):
     """Hop 1 returns metadata without tweet_results — also a clean ToolError."""
-    fake_two_hop_client.gql_get.return_value = {
-        "data": {
-            "article_result_by_rest_id": {
-                "result": {"__typename": "ArticleEntity", "metadata": {}}
+    fake_two_hop_client.gql_get.return_value = _as_twikit_return(
+        {
+            "data": {
+                "article_result_by_rest_id": {
+                    "result": {"__typename": "ArticleEntity", "metadata": {}}
+                }
             }
         }
-    }
+    )
     with pytest.raises(ToolError):
         await server.get_article("2048420352397864960")
     fake_two_hop_client.tweet_result.assert_not_called()

--- a/twitter_mcp/server.py
+++ b/twitter_mcp/server.py
@@ -282,10 +282,11 @@ async def get_article(article_id: str) -> str:
     client = await _get_client()
 
     # ── Hop 1: article rest_id → tweet rest_id ──────────────────────────
+    # twikit's transport returns (response_json, raw_response) — see issue #12.
     redirect_url = (
         f"{_GRAPHQL_BASE}/{_ARTICLE_REDIRECT_QUERY_ID}/{_ARTICLE_REDIRECT_OP_NAME}"
     )
-    redirect = await client.gql.gql_get(
+    redirect, _ = await client.gql.gql_get(
         redirect_url,
         {"articleEntityId": rest_id},
         {},
@@ -306,7 +307,7 @@ async def get_article(article_id: str) -> str:
         )
 
     # ── Hop 2: tweet → article body ─────────────────────────────────────
-    tweet_resp = await client.gql.tweet_result_by_rest_id(tweet_id)
+    tweet_resp, _ = await client.gql.tweet_result_by_rest_id(tweet_id)
     article = (
         (tweet_resp or {})
         .get("data", {})

--- a/uv.lock
+++ b/uv.lock
@@ -1448,7 +1448,7 @@ wheels = [
 
 [[package]]
 name = "twikit-mcp"
-version = "0.1.9"
+version = "0.1.10"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
Closes #12. Also ships the live-smoke workflow now that the `TWITTER_CT0` / `TWITTER_AUTH_TOKEN` repo secrets are configured.

## Why

0.1.9 shipped with `get_article` calling `.get()` directly on the result of `client.gql.gql_get(...)`, which is actually `tuple[dict, Response]` per `_vendor/twikit/client/client.py:214`. Every real call crashed:

```
get_article("2048420352397864960") → 'tuple' object has no attribute 'get'
```

Mocks in the test suite returned bare dicts, so the unit tests passed and the bug shipped to PyPI. A live-smoke workflow is included in this PR so the next time mocks lie about the transport contract (or X renames an op), CI catches it within 7 days without anyone remembering to test.

## What

**Three-character fix per the issue's diff** (`twitter_mcp/server.py`):

```python
- redirect = await client.gql.gql_get(redirect_url, {"articleEntityId": rest_id}, {})
+ redirect, _ = await client.gql.gql_get(redirect_url, {"articleEntityId": rest_id}, {})
...
- tweet_resp = await client.gql.tweet_result_by_rest_id(tweet_id)
+ tweet_resp, _ = await client.gql.tweet_result_by_rest_id(tweet_id)
```

**Test fixtures rewritten** (`tests/test_articles.py`): every helper that mocks a twikit gql call now returns `(payload, MagicMock(name="raw_response"))` — the actual transport contract. New regression test `test_get_article_unpacks_tuple_returned_by_twikit` pins this so a future refactor that drops the unpack reproduces the issue #12 crash and fails CI immediately.

**Live-smoke workflow** (`.github/workflows/live-smoke.yml`):

| Aspect | Choice |
|---|---|
| Triggers | `workflow_dispatch` + `schedule: cron 0 12 * * 1` (weekly Monday) + `push: branches: main` (paths-filtered to `twitter_mcp/**`) |
| Fork-safety | `if: github.repository == 'tangivis/twitter-mcp'` |
| Secret hygiene | `::add-mask::` applied to both cookie values before any other step; cookies file written via `jq -n --arg` (values never touch a shell command line); `chmod 600`; `permissions: {}`; `timeout-minutes: 5` |
| Concurrency | Cancel in-flight runs on new pushes (don't pile up against the same cookie) |
| Test target | `get_article("2048420352397864960")` (Jaden_riku's article from issue #10's verification); asserts non-empty `title` + `>1000` chars `plain_text` |

## Commits (TDD)

| | |
|---|---|
| `856f286` test | RED: fixtures now return `(dict, raw)` tuples; existing tests fail with the exact issue #12 error against current 0.1.9 server.py |
| `ad6312e` fix | GREEN: 3-character tuple unpack on both hops |
| `0a791bd` ci  | live-smoke workflow with masking, fork-block, concurrency, paths-filter |
| `4859254` chore | bump 0.1.9 → 0.1.10 |

## Test plan

- [x] `uv run ruff format --check .` + `uv run ruff check .` clean (pre-commit ran on every commit)
- [ ] CI green on PR (5 checks)
- [ ] After merge: publish.yml fires → 0.1.10 on PyPI + Release v0.1.10 auto-created
- [ ] live-smoke fires on the same main push (paths filter matches `twitter_mcp/server.py` change) → real X article fetched, `title="2026年，日本国运的分水岭"` + `body > 1000 chars`
- [ ] If live-smoke fails, the bug is in our two-hop logic vs. real X (not a mock issue) — diagnose from the workflow log

## Followup if live-smoke goes red

The most likely failure modes (in order of probability):

1. **Burner cookies expired / locked by X** — re-extract from the burner's browser, update `TWITTER_CT0` / `TWITTER_AUTH_TOKEN` secrets
2. **X rotated `ArticleRedirectScreenQuery` queryId** — refresh from `bundle.Articles.*.js`, see `docs/VENDORING.md`
3. **X changed the response shape** — issue + new patch

https://claude.ai/code/session_01YZ5NXtFwvf3yybuRVSzvPY

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZ5NXtFwvf3yybuRVSzvPY)_