### PR TITLE
fix: extract article media URL from media_info.original_img_url (closes #16)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "twikit-mcp"
-version = "0.1.11"
+version = "0.1.12"
 description = "Twitter/X MCP server powered by twikit — no API key needed, free forever"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_articles.py
+++ b/tests/test_articles.py
@@ -715,6 +715,35 @@ async def test_get_article_format_plain_no_media_entities_returns_empty_list(
     assert out["media"] == []
 
 
+async def test_get_article_format_plain_explicit_null_media_entities(
+    monkeypatch, fake_two_hop_client
+):
+    """media_entities: null (vs missing) → media: [], no TypeError on `for x in None`."""
+    payload = {
+        "data": {
+            "tweetResult": {
+                "result": {
+                    "__typename": "Tweet",
+                    "rest_id": "999",
+                    "article": {
+                        "article_results": {
+                            "result": {
+                                "rest_id": "999",
+                                "title": "t",
+                                "plain_text": "body",
+                                "media_entities": None,
+                            }
+                        }
+                    },
+                }
+            }
+        }
+    }
+    fake_two_hop_client.tweet_result.return_value = _as_twikit_return(payload)
+    out = json.loads(await server.get_article("999", format="plain"))
+    assert out["media"] == []
+
+
 async def test_get_article_format_full_returns_content_state(
     monkeypatch, fake_two_hop_client
 ):

--- a/tests/test_articles.py
+++ b/tests/test_articles.py
@@ -227,7 +227,17 @@ def _tweet_response_with_article(plain_text="full body 13984 chars goes here"):
                                     },
                                     "media_entities": [
                                         {
-                                            "media_url_https": f"https://pbs.twimg.com/media/M{i}.jpg"
+                                            "id": f"AbC{i}=",
+                                            "media_id": f"204842333717368422{i}",
+                                            "media_key": f"3_204842333717368422{i}",
+                                            "media_info": {
+                                                "__typename": "ApiImage",
+                                                "original_img_url": (
+                                                    f"https://pbs.twimg.com/media/M{i}.jpg"
+                                                ),
+                                                "original_img_width": 2400,
+                                                "original_img_height": 1600,
+                                            },
                                         }
                                         for i in range(10)
                                     ],
@@ -573,11 +583,15 @@ async def test_get_article_format_plain_includes_body_and_media_urls(
     assert "cover_media" not in payload
 
 
-async def test_get_article_format_plain_falls_back_to_media_url_when_https_absent(
+async def test_get_article_format_plain_extracts_from_media_info(
     monkeypatch, fake_two_hop_client
 ):
-    """media_entities entries use media_url_https when present, fall back to media_url."""
-    # First entry has only media_url, second has both, third is empty.
+    """Issue #16: article media URL lives at media_info.original_img_url.
+
+    The flat `media_url_https` / `media_url` keys (tweet schema, the wrong
+    field names #14's snippet used) do not exist on article media entities —
+    the URL is one level deeper inside `media_info`.
+    """
     payload = {
         "data": {
             "tweetResult": {
@@ -592,12 +606,24 @@ async def test_get_article_format_plain_falls_back_to_media_url_when_https_absen
                                 "preview_text": "p",
                                 "plain_text": "body",
                                 "media_entities": [
-                                    {"media_url": "http://legacy.example/a.jpg"},
+                                    # canonical shape — URL inside media_info
                                     {
-                                        "media_url_https": "https://new.example/b.jpg",
-                                        "media_url": "http://old.example/b.jpg",
+                                        "media_info": {
+                                            "__typename": "ApiImage",
+                                            "original_img_url": (
+                                                "https://pbs.twimg.com/media/A.jpg"
+                                            ),
+                                        }
                                     },
-                                    {},  # nothing usable
+                                    # video — different __typename, same URL slot
+                                    {
+                                        "media_info": {
+                                            "__typename": "ApiVideo",
+                                            "original_img_url": (
+                                                "https://pbs.twimg.com/media/B.png"
+                                            ),
+                                        }
+                                    },
                                 ],
                             }
                         }
@@ -609,10 +635,84 @@ async def test_get_article_format_plain_falls_back_to_media_url_when_https_absen
     fake_two_hop_client.tweet_result.return_value = _as_twikit_return(payload)
     out = json.loads(await server.get_article("999", format="plain"))
     assert out["media"] == [
-        "http://legacy.example/a.jpg",
-        "https://new.example/b.jpg",
-        None,
+        "https://pbs.twimg.com/media/A.jpg",
+        "https://pbs.twimg.com/media/B.png",
     ]
+
+
+async def test_get_article_format_plain_skips_unparseable_media_entries(
+    monkeypatch, fake_two_hop_client
+):
+    """Issue #16: drop Nones / empty-info / missing-info entries entirely.
+
+    Previously the projection emitted a `null` per missing URL; the
+    resulting `[null, null, ..., null]` array was pure noise to the LLM.
+    """
+    payload = {
+        "data": {
+            "tweetResult": {
+                "result": {
+                    "__typename": "Tweet",
+                    "rest_id": "999",
+                    "article": {
+                        "article_results": {
+                            "result": {
+                                "rest_id": "999",
+                                "title": "t",
+                                "plain_text": "body",
+                                "media_entities": [
+                                    None,
+                                    {},  # no media_info at all
+                                    {"media_info": None},  # explicit null
+                                    {"media_info": {}},  # empty dict
+                                    {"media_info": {"__typename": "ApiImage"}},
+                                    # only this last one is usable
+                                    {
+                                        "media_info": {
+                                            "original_img_url": (
+                                                "https://pbs.twimg.com/media/Z.jpg"
+                                            )
+                                        }
+                                    },
+                                ],
+                            }
+                        }
+                    },
+                }
+            }
+        }
+    }
+    fake_two_hop_client.tweet_result.return_value = _as_twikit_return(payload)
+    out = json.loads(await server.get_article("999", format="plain"))
+    assert out["media"] == ["https://pbs.twimg.com/media/Z.jpg"]
+
+
+async def test_get_article_format_plain_no_media_entities_returns_empty_list(
+    monkeypatch, fake_two_hop_client
+):
+    """Article without media_entities → media: []."""
+    payload = {
+        "data": {
+            "tweetResult": {
+                "result": {
+                    "__typename": "Tweet",
+                    "rest_id": "999",
+                    "article": {
+                        "article_results": {
+                            "result": {
+                                "rest_id": "999",
+                                "title": "t",
+                                "plain_text": "body",
+                            }
+                        }
+                    },
+                }
+            }
+        }
+    }
+    fake_two_hop_client.tweet_result.return_value = _as_twikit_return(payload)
+    out = json.loads(await server.get_article("999", format="plain"))
+    assert out["media"] == []
 
 
 async def test_get_article_format_full_returns_content_state(

--- a/twitter_mcp/server.py
+++ b/twitter_mcp/server.py
@@ -350,16 +350,22 @@ async def get_article(article_id: str, format: str = "plain") -> str:
             "cover_image": cover,
         }
     else:  # "plain"
+        # Article media URLs live at media_entities[*].media_info.original_img_url
+        # — NOT at the flat media_url_https / media_url that tweet schema uses
+        # (issue #16). Drop entries where the URL can't be extracted so callers
+        # don't see a list of nulls.
+        media = []
+        for m in article.get("media_entities") or []:
+            url = ((m or {}).get("media_info") or {}).get("original_img_url")
+            if url:
+                media.append(url)
         out = {
             "rest_id": article.get("rest_id"),
             "title": article.get("title"),
             "preview_text": article.get("preview_text", ""),
             "plain_text": article.get("plain_text", ""),
             "cover_image": cover,
-            "media": [
-                m.get("media_url_https") or m.get("media_url")
-                for m in article.get("media_entities", [])
-            ],
+            "media": media,
             "lifecycle_state": article.get("lifecycle_state"),
         }
     return json.dumps(out, ensure_ascii=False)

--- a/uv.lock
+++ b/uv.lock
@@ -1448,7 +1448,7 @@ wheels = [
 
 [[package]]
 name = "twikit-mcp"
-version = "0.1.11"
+version = "0.1.12"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
Closes #16.

## Why

v0.1.11's `format="plain"` returned `media: [null, null, ..., null]` for every real article. PR #14's snippet used tweet-schema field names (`media_url_https` / `media_url`); article media entities nest the URL one layer deeper inside `media_info`.

## Fix

```diff
- "media": [
-     m.get("media_url_https") or m.get("media_url")
-     for m in article.get("media_entities", [])
- ],
+ media = []
+ for m in article.get("media_entities") or []:
+     url = ((m or {}).get("media_info") or {}).get("original_img_url")
+     if url:
+         media.append(url)
```

Same nesting cover_media already used. Output is now URL-only, no nulls — drops entries we can't extract from rather than emitting placeholders.

## Commits (TDD)

| | |
|---|---|
| `70ef119` test | RED: fixture's `media_entities` now mirror the live shape (`media_info{__typename, original_img_url, dimensions}`); existing happy-path tests now assert the URL list extracted from there. Replaces the `media_url_https` fallback test (which pinned the wrong field name) with three issue #16 tests covering canonical extraction, unparseable-entry skipping, and the missing-key default. |
| `4a3cb06` fix | GREEN: read `media_info.original_img_url`, defensively None-guard each layer, drop entries without a URL. |
| `fc659ea` test+chore | Add explicit `media_entities: null` test (vs. missing key); bump 0.1.11 → 0.1.12. |

## Coverage

```
twitter_mcp/server.py    129 stmts    0 miss    100%
168 passed
```

Verified locally on Python 3.13 (sandbox can't run pytest on project's pinned 3.14.0rc2).

## Test plan

- [x] `uv run ruff format --check .` + `uv run ruff check .` clean (pre-commit ran on every commit)
- [x] Local pytest 168 passed, 100% coverage
- [ ] CI green on PR
- [ ] After merge: PyPI 0.1.12 + Release v0.1.12 auto-created; live-smoke fires on main push and verifies the Jaden_riku article still flows through (`title`, `plain_text > 1000`)
- [ ] First real `get_article(id, format="plain")` after release returns 10 actual `https://pbs.twimg.com/...` URLs, no nulls

https://claude.ai/code/session_01YZ5NXtFwvf3yybuRVSzvPY

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZ5NXtFwvf3yybuRVSzvPY)_