### PR TITLE
ci: add Claude Code GitHub Action (@claude mentions, Max plan auth)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,58 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # Optional: Customize the trigger phrase (default: @claude)
+          # trigger_phrase: "/claude"
+
+          # Optional: Trigger when specific user is assigned to an issue
+          # assignee_trigger: "claude-bot"
+
+          # Optional: Configure Claude's behavior with CLI arguments
+          # claude_args: |
+          #   --model claude-opus-4-1-20250805
+          #   --max-turns 10
+          #   --allowedTools "Bash(npm install),Bash(npm run build),Bash(npm run test:*),Bash(npm run lint:*)"
+          #   --system-prompt "Follow our coding standards. Ensure all new code has tests. Use TypeScript for new files."
+
+          # Optional: Advanced settings configuration
+          # settings: |
+          #   {
+          #     "env": {
+          #       "NODE_ENV": "test"
+          #     }
+          #   }


### PR DESCRIPTION
Wires up `@claude` mentions in this repo to the official [`anthropics/claude-code-action@v1`](https://github.com/anthropics/claude-code-action).

## What this lets you do

After merge, write `@claude <anything>` in:

- An issue body or title (on creation / assignment)
- An issue comment
- A PR review or PR review comment

…and Claude responds in-thread with full repo write access (commits, PR comments, issue updates).

**This is _mention-only_** — does NOT auto-review every PR. Auto-review is a separate workflow we can add later as `claude-review.yml` if you want it.

## Auth = Max plan, no API billing

Workflow uses `claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}`. The secret value is the `sk-ant-oat01...` token from `claude setup-token`, which is **subscription-derived, not an API key**:

- `sk-ant-oat01*` prefix = OAuth token tied to a Claude Pro/Max subscription → calls bill against subscription quota
- `sk-ant-api03*` prefix = API key from console.anthropic.com → pay-per-token

These are physically different auth paths on Anthropic's backend. You cannot accidentally hit API billing through an `oat01` token.

The `CLAUDE_CODE_OAUTH_TOKEN` repo secret has been added by @tangivis. The token is valid for 1 year per upstream.

## Workflow content

Matches `anthropics/claude-code-action/examples/claude.yml` verbatim **except for the auth field** (oauth_token instead of api_key). Optional `trigger_phrase` / `assignee_trigger` / `claude_args` / `settings` blocks kept commented in for easy future tweaking.

## Access control

By default the action only honors `@claude` mentions from users with **write permission** on the repo. The escape-hatch input `allowed_non_write_users` is documented as ⚠️ RISKY by upstream and is not set here. So:

- Random GitHub users on this public repo cannot trigger Claude.
- Repo collaborators (currently just @tangivis) can.

## Test plan

After merge:

1. Open any issue (or comment on an existing one) with body: `@claude hi, can you see this?`
2. Within ~30s a workflow run should fire under Actions → "Claude Code".
3. Claude posts a reply on the same issue/PR thread.
4. Cross-check: `https://console.anthropic.com` → Usage → API tab should show **no new requests** (token routes to subscription, not API).

If step 4 shows new API rows instead of nothing, something is misconfigured — file a follow-up.

## Out of scope (follow-ups)

- Auto PR-review workflow (`claude-review.yml` with `pull_request: types: [opened, synchronize]` + a `prompt:` instruction).
- `block_user` / `mute_user` MCP tools (deferred from #18).

https://claude.ai/code/session_01YZ5NXtFwvf3yybuRVSzvPY

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZ5NXtFwvf3yybuRVSzvPY)_