### PR TITLE
ci: add Claude PR review + issue triage workflows

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,0 +1,60 @@
+name: Claude Issue Triage
+
+# Auto-labels new issues based on existing repo labels. Inline-prompt
+# version of anthropics/claude-code-action/examples/issue-triage.yml —
+# the official example uses a `/label-issue` slash command requiring
+# `.claude/commands/label-issue.md` + a custom script. We skip that
+# and just inline the instructions; upgrade to a slash command later
+# if the prompt grows.
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  triage-issue:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code for Issue Triage
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # NOTE: with the default (allowed_non_write_users not set),
+          # only issues opened by users with write permission trigger
+          # this workflow. For a single-maintainer repo that's fine.
+          # If you start getting issues from outside contributors and
+          # want them auto-triaged too, add:
+          #   allowed_non_write_users: "*"
+          # but be aware that's the ⚠️ RISKY input — combined with the
+          # strict --allowedTools below it's bounded, but think before
+          # flipping it on.
+          prompt: |
+            REPO: ${{ github.repository }}
+            ISSUE: ${{ github.event.issue.number }}
+
+            Triage this newly-opened issue. Steps:
+
+            1. Read the issue body and title with `gh issue view ${{ github.event.issue.number }}`.
+            2. List existing repo labels with `gh label list`.
+            3. Apply the 1–3 most relevant existing labels using
+               `gh issue edit ${{ github.event.issue.number }} --add-label "<name>"`.
+            4. Do NOT create new labels. If no existing label fits, leave
+               it unlabeled.
+            5. Do NOT post a triage comment unless the issue is missing
+               critical info (no repro steps for a bug, no version, etc.)
+               in which case post one short comment asking for it.
+
+            Keep it terse — labels first, words last.
+          claude_args: |
+            --allowedTools "Bash(gh label list:*),Bash(gh issue view:*),Bash(gh issue edit:*),Bash(gh issue comment:*)"

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,75 @@
+name: PR Review with Progress Tracking
+
+# Auto-runs Claude on every new / synced PR. Adapted verbatim from
+# anthropics/claude-code-action/examples/pr-review-comprehensive.yml,
+# with the auth field swapped to OAuth (Max plan) instead of API key.
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+jobs:
+  review-with-tracking:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: PR Review with Progress Tracking
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # Enable progress tracking
+          track_progress: true
+
+          # Your custom review instructions
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Perform a comprehensive code review with the following focus areas:
+
+            1. **Code Quality**
+               - Clean code principles and best practices
+               - Proper error handling and edge cases
+               - Code readability and maintainability
+
+            2. **Security**
+               - Check for potential security vulnerabilities
+               - Validate input sanitization
+               - Review authentication/authorization logic
+
+            3. **Performance**
+               - Identify potential performance bottlenecks
+               - Review database queries for efficiency
+               - Check for memory leaks or resource issues
+
+            4. **Testing**
+               - Verify adequate test coverage
+               - Review test quality and edge cases
+               - Check for missing test scenarios
+
+            5. **Documentation**
+               - Ensure code is properly documented
+               - Verify README updates for new features
+               - Check API documentation accuracy
+
+            Provide detailed feedback using inline comments for specific issues.
+            Use top-level comments for general observations or praise.
+
+          # Tools for comprehensive PR review
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+
+# When track_progress is enabled:
+# - Creates a tracking comment with progress checkboxes
+# - Includes all PR context (comments, attachments, images)
+# - Updates progress as the review proceeds
+# - Marks as completed when done


### PR DESCRIPTION
Adds two more Claude Code workflows on top of the `@claude` mention from #20.

## What lands

| File | Trigger | What Claude does |
|---|---|---|
| `.github/workflows/pr-review.yml` | `pull_request: opened/synchronize/ready_for_review/reopened` | Auto-reviews every PR with a structured rubric (code quality, security, performance, testing, docs). Posts a tracking comment + inline review comments. |
| `.github/workflows/issue-triage.yml` | `issues: opened` | Auto-labels new issues using existing repo labels (no new labels created). Optionally posts one clarifying comment if critical info is missing. |

Both share the existing `CLAUDE_CODE_OAUTH_TOKEN` repo secret → bills against your Max plan quota, no API spend.

## Notes on adaptation

- **pr-review.yml**: Verbatim copy of `anthropics/claude-code-action/examples/pr-review-comprehensive.yml` with one change — `anthropic_api_key` → `claude_code_oauth_token`. `track_progress: true` kept on for visual feedback.
- **issue-triage.yml**: The upstream `issue-triage.yml` example uses a `/label-issue` slash command that needs `.claude/commands/label-issue.md` + a custom script in the repo. We skip the slash command and inline the triage instructions directly — keeps it self-contained. Easy to upgrade to a slash command later if the prompt grows.

## Security posture

| Workflow | Access control | Tool allowlist |
|---|---|---|
| pr-review | Default (any PR triggers — that's the point) | `mcp__github_inline_comment__create_inline_comment` + `gh pr comment/diff/view` |
| issue-triage | Default = write-only (only @tangivis's issues trigger). Comment in file documents the `allowed_non_write_users: "*"` escape hatch for future external contributors. | `gh label list/issue view/edit/comment` |

The strict `--allowedTools` allowlists cap blast radius even if a malicious PR / issue body tried prompt injection — Claude can post comments and apply existing labels, nothing more. No bash exec, no file edits, no git ops.

## Test plan

- [ ] CI green on this PR (5 checks)
- [ ] **Self-test**: when this PR is merged, the next PR I open should automatically get a Claude review comment within ~30s of opening
- [ ] **Triage test**: when @tangivis opens a new issue, it should get 1–3 labels applied within ~30s
- [ ] Console.anthropic.com → Usage → API tab shows no new requests (calls route through Max subscription)

## Out of scope (further follow-ups)

Per @tangivis's "B" selection, we're skipping the other 5 official examples for now:

- `pr-review-filtered-paths.yml` — narrow PR review to critical files
- `pr-review-filtered-authors.yml` — stricter rules for external contributors
- `issue-deduplication.yml` — auto-detect duplicate issues
- `ci-failure-auto-fix.yml` — auto-fix red CI (powerful but risky; consider after observing pr-review for a bit)
- `test-failure-analysis.yml` — analyze failing tests
- `manual-code-analysis.yml` — on-demand code analysis

All trivially addable later, all share the same OAuth secret.

https://claude.ai/code/session_01YZ5NXtFwvf3yybuRVSzvPY

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZ5NXtFwvf3yybuRVSzvPY)_