### PR TITLE
ci: auto-summon @claude on live-smoke failure (close the TDD loop)

### DIFF
--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -205,29 +205,72 @@ jobs:
       # This makes the failure detail readable via mcp__github__issue_read,
       # closing the observability gap (we can't read raw run logs from MCP).
       # Skips silently if the issue doesn't exist yet (curl returns 404).
-      - name: Post failure summary to tracking issue #37
+      - name: Post failure summary + auto-summon @claude on issue #37
         if: failure() && hashFiles('smoke.log') != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
         run: |
-          # Extract just the ✗ lines (one per failed read) — the rest is noise.
+          # Extract just the ✗ lines (one per failed read).
           fails=$(grep -E '^\s*✗' smoke.log || true)
           if [ -z "$fails" ]; then
             echo "No ✗ lines in log; nothing to post."
             exit 0
           fi
-          # Build the JSON payload with jq so newlines / quotes in $fails are
-          # safe. Single object: {"body": "..."}.
+
+          sha7="${SHA:0:7}"
+
+          # Per-SHA dedup. Two failure paths converge here:
+          #   1. cron re-runs on the same `main` SHA each Monday → don't keep
+          #      pinging Claude every week for the same already-known failure.
+          #   2. Manual `workflow_dispatch` re-runs on the same SHA → same.
+          # We grep existing comments on issue #37 for the exact opener
+          # "live-smoke failed on `<sha7>`" — that's the unique header we
+          # always emit below, so it's a reliable dedup key.
+          existing=$(curl -sS \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/$REPO/issues/37/comments?per_page=100" \
+            | jq -r '.[].body' \
+            | grep -cF "live-smoke failed on \`$sha7\`" || true)
+          if [ "$existing" -gt 0 ]; then
+            echo "Already summoned @claude for $sha7; skipping (dedup)."
+            exit 0
+          fi
+
+          # Build comment body. The `@claude` mention triggers `claude.yml`
+          # which spawns a bot session that opens a TDD-fix PR. The prompt
+          # is intentionally explicit so the bot doesn't guess between
+          # the two valid fix paths (relax assertion vs. patch tool/vendor).
+          read -r -d '' INSTRUCTIONS <<'EOM' || true
+          @claude please open a draft PR that fixes this. Read the ✗ line(s) above and follow the project's TDD pattern:
+
+          1. **Identify** which read tool failed and what the failure mode is (assertion, AttributeError, KeyError, NotFound, TooManyRequests, …).
+          2. **Decide which fix path applies:**
+             - **(a) Genuine tool drift** (queryId rotated, response field renamed, X moved an endpoint) → patch in `twitter_mcp/_vendor/twikit/`. Add a `# twitter-mcp patch (#<this-issue-37-comment-id>)` marker the same way `_vendor/twikit/client/gql.py::tweet_result_by_rest_id` is marked for issue #10. Document the patch in `docs/VENDORING.md` under the "本地 patch 清单" table.
+             - **(b) Brittle live-smoke assertion** (X legitimately gates this data for the burner, e.g. follower lists for accounts you don't follow) → loosen the validator in `.github/workflows/live-smoke.yml` to shape-only. Explain *why* in the comment alongside the validator (the existing `v_search` / `v_trends` / `v_followers` comments are the template).
+             - **(c) Defensive parse fix** (response shape changed but tool can recover with `.get(...)` defaults) → patch `twitter_mcp/server.py` or the relevant `_vendor/twikit/*.py` model with `.get()` defaults the same way `User.__init__` was hardened in 0.1.4 / `Tweet` in 0.1.5.
+          3. **Add a regression test** in `tests/test_tools.py` (or a new test file) that reproduces the failure mode against a mock and would have caught it pre-merge.
+          4. Keep all existing tests green and `--cov-fail-under=95` on `twitter_mcp/server.py`.
+          5. Open the PR as draft; do NOT merge.
+
+          If multiple ✗ lines, do them all in one PR but in separate commits (one TDD red→green cycle per failure mode).
+
+          Context this issue (#37) tracks: `live-smoke` runs against real X with burner cookies; failures are recurring due to X's anti-abuse / gating drift. See PR #38 for the observability + assertion-relaxation precedent.
+          EOM
+
           payload=$(jq -nc \
             --arg url "$RUN_URL" \
-            --arg sha "${GITHUB_SHA:0:7}" \
+            --arg sha "$sha7" \
             --arg fails "$fails" \
-            '{body: "live-smoke failed on `\($sha)` — [run](\($url))\n\n```\n\($fails)\n```"}')
-          # Try to comment; ignore if issue #37 doesn't exist (404).
+            --arg instr "$INSTRUCTIONS" \
+            '{body: "live-smoke failed on `\($sha)` — [run](\($url))\n\n```\n\($fails)\n```\n\n---\n\n\($instr)"}')
+
           curl -sS -X POST \
             -H "Authorization: Bearer $GH_TOKEN" \
             -H "Accept: application/vnd.github+json" \
             -d "$payload" \
-            "https://api.github.com/repos/${{ github.repository }}/issues/37/comments" \
-            -w "\nHTTP %{http_code}\n" || true
+            "https://api.github.com/repos/$REPO/issues/37/comments" \
+            -w "\nHTTP %{http_code}\n"


### PR DESCRIPTION
## Why

PR #38 added observability (auto-comment to #37 on live-smoke fail) but the next step — _someone reads the comment and starts TDD_ — was still manual. This closes that gap so the loop is end-to-end auto, with a human gate only at the merge step.

## Before vs after

**Before PR #38:** failures were invisible from MCP — had to copy-paste logs.

**After PR #38:** failures auto-comment to #37 with the `✗` lines. Still manual to fix.

**After this PR:** the auto-comment includes an `@claude` mention + explicit TDD instructions. `claude.yml`'s bot session picks it up, opens a draft fix PR. Human still reviews + merges.

```
live-smoke fails
  → ✗ lines auto-comment on #37 (with @claude)
  → bot session spawns
  → bot opens draft PR (TDD: red test → fix → green)
  → human reviews + merges
```

## Per-SHA dedup

Without dedup, the cron re-run every Monday would re-summon `@claude` on the same SHA forever → bot-PR spam. The new step `grep -cF`s existing #37 comments for the unique header `live-smoke failed on \`<sha7>\`` and exits 0 if seen.

Two failure paths converge to the same dedup:
1. Weekly cron re-run on the same `main` SHA.
2. Manual `workflow_dispatch` re-run.

## Bot prompt is intentionally explicit

The auto-comment tells the bot exactly which of the three fix paths to take:

| Path | When | Precedent |
|---|---|---|
| (a) Vendor-tree patch | queryId rotated / X moved an endpoint / field renamed | 0.1.9's `withArticlePlainText` patch (issue #10) |
| (b) Loosen live-smoke assertion | X legitimately gates burner (e.g. follower lists private) | PR #38's `v_search` / `v_trends` / `v_followers` |
| (c) Defensive `.get()` fix | Response shape drifted but tool can recover | 0.1.4 `User.__init__` / 0.1.5 `Tweet` defensive parsing |

Plus: regression test in `tests/test_tools.py`, 480+ tests green, coverage gate held, **draft PR only** — never auto-merged.

## What this does NOT do

- ❌ **No auto-summon for `ci.yml` failures.** Code bugs caught by mock tests should be human-reviewed; auto-fixing CI invites churn.
- ❌ **No auto-merge.** Vendor-tree fixes especially can ship junk if the bot guesses the wrong queryId; merge stays human-gated.
- ❌ **No auto-close on green.** #37 stays open as a long-lived activity log.

## Test plan

- [x] `python -c "import yaml; yaml.safe_load(...)"` — YAML parses
- [x] All 480 unit tests still pass; 100% server.py coverage held
- [ ] CI green on PR (lint + 3 platforms + MCP protocol)
- [ ] After merge: next live-smoke failure (whenever it happens) should land on #37 with `@claude`, then a bot PR shortly after
- [ ] If first auto-bot PR misses the mark, I close it and we iterate on the prompt

https://claude.ai/code/session_01YZ5NXtFwvf3yybuRVSzvPY

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZ5NXtFwvf3yybuRVSzvPY)_