### PR TITLE
fix: get_user_info attribute name + get_lists vendor defensive .get() (issue #37 live-smoke)

### DIFF
--- a/docs/VENDORING.md
+++ b/docs/VENDORING.md
@@ -44,6 +44,7 @@ PyPI 上的 twikit 2.3.3 有两个已知 bug：
 | 0.1.4 | `_vendor/twikit/user.py` | `User.__init__` 全面防御化，所有 `legacy.*` 字段改 `.get()` 带默认值 |
 | 0.1.5 | `_vendor/twikit/tweet.py` | `Tweet` 属性全面防御化：`text`/`created_at`/`lang`/`favorite_count`/`retweet_count`/`reply_count`/`favorited`/`is_quote_status` 以及 `entities.*` 子树（hashtags/urls/media）都走 `.get()`。构造时 `_data["legacy"]` 也改为可选。|
 | 0.1.9 | `_vendor/twikit/client/gql.py` | `GQLClient.tweet_result_by_rest_id` 把 `fieldToggles.withArticlePlainText` 从 `False` 翻成 `True`。这是 issue #10 修复 `get_article` 的关键一步：上游默认抑制 article 正文，翻成 `True` 后 `.article.article_results.result.plain_text` 才会真的填充。改动在源文件里加了 `# twitter-mcp patch (issue #10)` 注释,下次 vendor 刷新时不要漏掉。|
+| 0.1.21 | `_vendor/twikit/client/client.py` | `Client.get_lists` 防御化 items[1] 遍历。issue #37 暴露:burner 0 lists 时 X 在 items[1] 塞了 promo 卡片或没有 `itemContent.list` 的 cell,上游用 `list["item"]["itemContent"]["list"]` 直挂 KeyError。改成 `.get()` 链 + 跳过没 list payload 的 entry。打了 `# twitter-mcp patch (issue #37)` 标记 + `tests/test_vendor.py::test_get_lists_skips_non_list_entries` 双重 guard,下次 vendor 刷新别漏。|
 
 ### 为什么要防御化 `User.__init__`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "twikit-mcp"
-version = "0.1.20"
+version = "0.1.21"
 description = "Twitter/X MCP server powered by twikit — no API key needed, free forever"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -305,7 +305,7 @@ def _fake_user_full(
     is_blue_verified=True,
     location="The Cloud",
     url="https://claude.com",
-    profile_image_url_https="https://pbs.twimg.com/avatar/x.jpg",
+    profile_image_url="https://pbs.twimg.com/avatar/x.jpg",
     protected=False,
 ):
     return SimpleNamespace(
@@ -321,7 +321,13 @@ def _fake_user_full(
         is_blue_verified=is_blue_verified,
         location=location,
         url=url,
-        profile_image_url_https=profile_image_url_https,
+        # twikit's `User.profile_image_url` (NO `_https` suffix on the
+        # attribute, even though the X JSON key is `profile_image_url_https`).
+        # Issue #37: the test fake formerly used the JSON key shape, so
+        # `server.get_user_info` reading `u.profile_image_url_https` looked
+        # green under mocks but blew up on the real model with
+        # `AttributeError: 'User' object has no attribute …_https`.
+        profile_image_url=profile_image_url,
         protected=protected,
     )
 

--- a/tests/test_vendor.py
+++ b/tests/test_vendor.py
@@ -107,6 +107,69 @@ def test_search_uses_gql_post():
     assert "gql_get" not in source, "search_timeline should NOT use gql_get"
 
 
+def test_get_lists_skips_non_list_entries():
+    """twitter-mcp patch (issue #37): get_lists must defend against
+    items[1] entries that don't carry an `itemContent.list` payload —
+    upstream raised KeyError, our patched version skips them.
+
+    Source-level check (cheap regression for the patch marker)."""
+    import inspect
+
+    from twitter_mcp._vendor.twikit.client.client import Client
+
+    source = inspect.getsource(Client.get_lists)
+    assert "issue #37" in source, "patch marker for issue #37 missing"
+    assert ".get(" in source, "patch should use .get() chain for safety"
+    # Upstream's brittle bracket-access form must NOT come back on a vendor
+    # refresh; if a future twikit sync drops this patch we want CI to fail.
+    assert 'list["item"]["itemContent"]["list"]' not in source, (
+        "raw bracket access still present; #37 patch was dropped"
+    )
+
+
+async def test_get_lists_runtime_handles_nonlist_entries():
+    """Issue #37 behavioral regression: when X returns a list-management
+    timeline whose items[1] holds only non-list entries (the burner-with-0-lists
+    case), get_lists must yield an empty Result without raising KeyError.
+
+    Pre-patch this raised `KeyError: 'list'` at the second hop of
+    `list["item"]["itemContent"]["list"]`.
+    """
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock
+
+    from twitter_mcp._vendor.twikit.client.client import Client
+
+    # response shape: top-level "entries" — first entry's "items" is a stub
+    # (items[0] in the vendor code), second entry's "items" is the lists slot
+    # (items[1]) and contains only entries that lack the `list` key. Last
+    # entry carries the cursor (`entries[-1]["content"]["value"]`).
+    fake_response = {
+        "entries": [
+            {"items": ["sentinel-items[0]"]},
+            {
+                "items": [
+                    {"item": {"itemContent": {}}},  # no list key
+                    {
+                        "item": {"itemContent": {"some_other_key": "promo"}}
+                    },  # no list key
+                ]
+            },
+            {"content": {"value": "next-cursor"}},
+        ]
+    }
+
+    # Skip Client.__init__ — we don't need cookies/HTTP; only the patched
+    # `get_lists` body runs.
+    client = Client.__new__(Client)
+    client.gql = SimpleNamespace(
+        list_management_pace_timeline=AsyncMock(return_value=(fake_response, None))
+    )
+
+    result = await client.get_lists()
+    assert list(result) == []
+
+
 # ── Phase 3: server.py uses vendored twikit ───────────
 
 

--- a/twitter_mcp/_vendor/twikit/client/client.py
+++ b/twitter_mcp/_vendor/twikit/client/client.py
@@ -3534,9 +3534,20 @@ class Client:
         if len(items) < 2:
             return Result([])
 
+        # twitter-mcp patch (issue #37): X's list-management timeline puts
+        # heterogeneous entries in items[1] — actual lists, "create new list"
+        # promo cards, and (for accounts with 0 lists) cells that have no
+        # itemContent.list key at all. Upstream chained brackets straight
+        # through, raising KeyError on the non-list entries, so an account
+        # with zero lists couldn't even call get_lists without it
+        # exploding. Walk the path with .get() defaults instead and skip
+        # entries that don't carry a list payload.
         lists = []
         for list in items[1]:
-            lists.append(List(self, list["item"]["itemContent"]["list"]))
+            list_payload = list.get("item", {}).get("itemContent", {}).get("list")
+            if list_payload is None:
+                continue
+            lists.append(List(self, list_payload))
 
         next_cursor = entries[-1]["content"]["value"]
 

--- a/twitter_mcp/server.py
+++ b/twitter_mcp/server.py
@@ -312,7 +312,7 @@ async def get_user_info(
             # Expose both so callers can pick. (PR #23 review feedback.)
             "verified": u.verified,
             "is_blue_verified": u.is_blue_verified,
-            "profile_image_url": u.profile_image_url_https,
+            "profile_image_url": u.profile_image_url,
             "protected": u.protected,
             "location": u.location,
             "url": u.url,

--- a/uv.lock
+++ b/uv.lock
@@ -1448,7 +1448,7 @@ wheels = [
 
 [[package]]
 name = "twikit-mcp"
-version = "0.1.20"
+version = "0.1.21"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Summary

Closes the failure auto-reported by issue #37 on f80b330. Two real bugs, both classic mock-vs-reality drift the live-smoke run finally surfaced after sitting green under PRs for months:

```
✗ get_user_info: AttributeError: 'User' object has no attribute 'profile_image_url_https'
✗ get_lists: KeyError: 'list'
```

| Bug | Where | Why mocks missed it | Fix path (per PR #39 prompt) |
|---|---|---|---|
| 1 | `server.py:315` reads `u.profile_image_url_https` | `_fake_user_full` mirrored the X-JSON-key shape, real `User.profile_image_url` has no `_https` suffix on the attribute | (c) defensive parse fix — server-side attribute rename + fixture realignment |
| 2 | `_vendor/twikit/client/client.py::get_lists` brackets `entry["item"]["itemContent"]["list"]` | Tests fed a `Result([List, List])` directly, never the raw timeline shape | (a) vendor-tree patch — `.get()` chain + skip entries missing the list payload |

Both fixes follow the project's TDD pattern: red test commit → green fix commit → docs+chore commit.

## Why these never surfaced before

- Bug 1 has been latent since 0.1.14 (when `get_user_info` was added).
- Bug 2 has been latent since 0.1.18 (Tier 2B, when `get_lists` was added).
- Neither tool was in live-smoke until PR #35 (0.1.20). PR #38's relaxed-assertion + observability fix is what actually let the failures surface as readable signal on issue #37.

## Three-commit TDD breakdown

```
test: red — failing tests reproducing issue #37 live-smoke bugs        (28d92d3)
fix:  green — repair two bugs surfaced by issue #37 live-smoke         (66aafe7)
docs+chore: bump to v0.1.21, log issue #37 vendor patch                (15804e3)
```

Vendor patch carries `# twitter-mcp patch (issue #37)` marker (mirrors 0.1.9's pattern for issue #10) so a future vendor refresh can't silently drop it. `tests/test_vendor.py::test_get_lists_skips_non_list_entries` source-asserts the marker; `…_runtime_handles_nonlist_entries` is the behavioral guard that constructs a fake response and confirms get_lists yields `[]` instead of `KeyError`.

## Test plan

- [x] All 482 tests pass (480 prior + 2 new vendor regression tests).
- [x] `twitter_mcp/server.py` coverage: 100% (775/775).
- [x] `ruff format` + `ruff check` clean (pre-commit).
- [ ] CI green on PR (lint + 3-platform test + MCP protocol).
- [ ] Claude PR review pass.
- [ ] After merge: live-smoke re-runs on the new SHA. Both ✗ should turn ✓; if anything else surfaces, the auto-loop posts to #37 and we cycle again.

## Closes

Issue #37 is the long-lived activity log so it stays open. The auto-comment from f80b330 is the one this PR closes (in the activity-log sense, not GH-ref sense).

https://claude.ai/code/session_01YZ5NXtFwvf3yybuRVSzvPY

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZ5NXtFwvf3yybuRVSzvPY)_