### PR TITLE
feat: full PR autonomy (JSON review + 5-iter @claude loop + auto-merge) + SDD guards

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,35 @@
+## Summary
+
+<!-- 1–3 sentences: what this PR does and why. Bot-opened PRs from
+auto-fix loops should reference the triggering issue/comment. -->
+
+## Test plan
+
+<!-- What would convince a reviewer it works? Be concrete. -->
+
+- [ ] All existing tests pass (`uv run pytest -q`).
+- [ ] `twitter_mcp/server.py` coverage stays at 100% (`--cov-fail-under=95`).
+- [ ] `ruff format` + `ruff check` clean.
+
+## Spec / SDD checklist
+
+(Skip a section if not applicable. Marking the boxes is the contract — leaving them blank tells the reviewer you skipped on purpose.)
+
+- [ ] **New / changed MCP tool?** Tool docstring states args + output JSON shape + which `twikit` method backs it + which typed errors are translated.
+- [ ] **Test fixture changed?** New / renamed attributes on `_fake_*` factories match the real `twikit` model — `tests/test_fixture_shapes.py` will catch drift, but please double-check before pushing.
+- [ ] **Vendor-tree patch?** Carries `# twitter-mcp patch (issue #N)` marker AND a row in `docs/VENDORING.md` "本地 patch 清单" table.
+- [ ] **New live-smoke target?** Added a validator in `.github/workflows/live-smoke.yml` that's shape-only (don't assert `len > 0` if X may legitimately gate the burner).
+- [ ] **Tool count changed?** Bumped the count in `tests/test_vendor.py::test_server_still_works` AND in `README.md` / `docs/TECHNICAL.md` / `docs/VENDORING.md` / `CONTRIBUTING.md` references.
+
+## Closes / refs
+
+<!-- Issue / PR refs — `closes #N`, `refs #N`, links to live-smoke runs, etc. -->
+
+---
+
+<!--
+Auto-fix-loop note for bot-opened PRs: the auto-summon comment will
+include `<!-- auto-fix-iter -->` as a marker. The 5-iteration cap counts
+those markers; after 5, the loop escalates to a `needs-human` issue
+and stops summoning. See PR #43 for the design.
+-->

--- a/.github/scripts/auto_summon_claude.sh
+++ b/.github/scripts/auto_summon_claude.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Auto-summon @claude on a PR with iteration cap + escalation.
+#
+# Used by:
+#   - pr-review.yml when MiniMax decision is "request-changes"
+#   - ci.yml when any required check fails on a PR
+#
+# Logic:
+#   - Counts existing comments on the PR matching the marker
+#     `<!-- auto-fix-iter -->`. That's iteration N (already attempted).
+#   - If N+1 ≤ MAX_ITER (5): post `@claude please fix (iter N+1/MAX)` with
+#     `body_extra` (the failure context) appended, plus the marker comment.
+#   - If N+1 > MAX_ITER: open a tracking issue with the same context, post
+#     a non-summoning comment on the PR explaining the cap was hit, and
+#     stop (no more @claude on this PR).
+#
+# Required env:
+#   GH_TOKEN        — Bearer token (workflow secrets.GITHUB_TOKEN)
+#   REPO            — owner/repo
+#   PR_NUM          — PR number
+#   REASON          — short label for the trigger ("MiniMax review",
+#                     "Lint & Format", "Test (ubuntu)", …)
+#   BODY_FILE       — path to a markdown file with the full failure context
+#                     (review body, CI log excerpt, etc.). Pasted verbatim.
+#
+# Optional env:
+#   MAX_ITER        — default 5
+
+set -euo pipefail
+
+: "${GH_TOKEN:?}"
+: "${REPO:?}"
+: "${PR_NUM:?}"
+: "${REASON:?}"
+: "${BODY_FILE:?}"
+MAX_ITER="${MAX_ITER:-5}"
+
+MARKER="<!-- auto-fix-iter -->"
+
+api() {
+  curl -sS \
+    -H "Authorization: Bearer $GH_TOKEN" \
+    -H "Accept: application/vnd.github+json" \
+    "$@"
+}
+
+# Count prior auto-summons by greping the marker in PR comments. We page
+# up to 200 comments — far more than any sane PR ever needs.
+prior=$(api "https://api.github.com/repos/$REPO/issues/$PR_NUM/comments?per_page=100" \
+        | jq -r '.[].body' \
+        | grep -cF "$MARKER" || true)
+next=$((prior + 1))
+
+if [ ! -s "$BODY_FILE" ]; then
+  echo "::warning::BODY_FILE ($BODY_FILE) is empty; nothing to post."
+  exit 0
+fi
+
+if [ "$next" -le "$MAX_ITER" ]; then
+  # Build the @claude summon comment.
+  jq -nc \
+    --arg marker "$MARKER" \
+    --arg reason "$REASON" \
+    --arg n "$next" \
+    --arg max "$MAX_ITER" \
+    --rawfile body "$BODY_FILE" \
+    '{body: ($marker + "\n\n@claude auto-fix iteration \($n)/\($max) — triggered by **\($reason)**.\n\nPlease address the feedback below by pushing a fix to this branch (TDD: red regression test → green fix → ensure all 480+ tests stay green and `--cov-fail-under=95`). After your push, the workflows re-run automatically; if the next review/CI is clean, the PR auto-merges. If you cannot fix this in one round, leave a comment explaining why instead of pushing a half-finished change.\n\n---\n\n\($body)")}' \
+    > /tmp/summon.json
+
+  api -X POST \
+    -d @/tmp/summon.json \
+    "https://api.github.com/repos/$REPO/issues/$PR_NUM/comments" \
+    -o /dev/null \
+    -w "Posted @claude summon (iter $next/$MAX_ITER) → HTTP %{http_code}\n"
+  exit 0
+fi
+
+# Cap hit. Open escalation issue + post non-summoning explainer.
+echo "Auto-fix cap reached ($prior prior summons, MAX=$MAX_ITER). Escalating."
+
+jq -nc \
+  --arg pr "$PR_NUM" \
+  --arg reason "$REASON" \
+  --arg max "$MAX_ITER" \
+  --rawfile body "$BODY_FILE" \
+  '{
+    title: "Auto-fix cap hit on PR #\($pr) — needs human review",
+    body: "Auto-fix loop on **PR #\($pr)** reached the iteration cap (**\($max)/\($max)**) without going green. The bot has stopped pushing fixes; a maintainer needs to look.\n\nLast trigger: **\($reason)**\n\n---\n\n\($body)\n\n---\n\nSee PR #\($pr) for the full conversation and prior auto-fix attempts.",
+    labels: ["ci", "needs-human"]
+  }' > /tmp/issue.json
+
+issue_url=$(api -X POST \
+  -d @/tmp/issue.json \
+  "https://api.github.com/repos/$REPO/issues" \
+  | jq -r '.html_url // ""')
+
+# Post a non-summoning explainer on the PR (no `@claude`, just info).
+jq -nc \
+  --arg url "$issue_url" \
+  --arg max "$MAX_ITER" \
+  --arg reason "$REASON" \
+  '{body: "🛑 Auto-fix cap reached (\($max)/\($max)). Last trigger: **\($reason)**.\n\nEscalated to: \($url)\n\nNo more @claude summons will fire on this PR; a human maintainer needs to inspect."}' \
+  > /tmp/explain.json
+
+api -X POST \
+  -d @/tmp/explain.json \
+  "https://api.github.com/repos/$REPO/issues/$PR_NUM/comments" \
+  -o /dev/null \
+  -w "Posted escalation explainer → HTTP %{http_code}\n"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,3 +71,53 @@ jobs:
           echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"ci","version":"0.1"}}}' \
             | uv run python -m twitter_mcp.server \
             | uv run python -c "import json, sys; resp = json.loads(sys.stdin.readline()); assert resp['result']['serverInfo']['name'] == 'twitter'; print('MCP handshake OK')"
+
+  # ─── PR auto-fix loop ───
+  # When ANY of the gating jobs (lint/test×3/protocol) fails on a PR, this
+  # job auto-summons @claude with iter cap of 5 + escalation to issue (same
+  # cap logic as pr-review.yml's request-changes path). Doesn't run on
+  # push-to-main fails — those go straight to the live-smoke / publish
+  # error paths.
+  ci-failure-auto-fix:
+    name: Auto-summon @claude on CI failure
+    needs: [lint, test, protocol]
+    if: always() && github.event_name == 'pull_request' && (needs.lint.result == 'failure' || needs.test.result == 'failure' || needs.protocol.result == 'failure')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Build failure summary
+        env:
+          LINT: ${{ needs.lint.result }}
+          TEST: ${{ needs.test.result }}
+          PROTO: ${{ needs.protocol.result }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          {
+            echo "**Failed CI jobs:**"
+            [ "$LINT" = "failure" ]  && echo "- ❌ Lint & Format"
+            [ "$TEST" = "failure" ]  && echo "- ❌ Test (Python 3.14, one or more platforms)"
+            [ "$PROTO" = "failure" ] && echo "- ❌ MCP Protocol Check"
+            echo
+            echo "Run: $RUN_URL"
+            echo
+            echo "_(Workflow logs aren't readable from MCP — open the run URL above to see the failing step's output. Common patterns:)_"
+            echo "- **Lint** → \`uv run ruff format .\` + \`uv run ruff check . --fix\`"
+            echo "- **Test** → run \`uv run pytest -x -q\` locally; an assertion / import / coverage drop will be in the output"
+            echo "- **MCP Protocol** → \`uv run python -m twitter_mcp.server\` should respond to a JSON-RPC initialize within seconds; fails usually mean a \`server.py\` import error"
+          } > failure.md
+
+      - name: Auto-summon @claude
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+          REASON: "CI failure"
+          BODY_FILE: failure.md
+        run: bash .github/scripts/auto_summon_claude.sh

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,60 +1,186 @@
-name: Claude Issue Triage
+name: Issue triage (MiniMax M2)
 
-# Auto-labels new issues based on existing repo labels. Inline-prompt
-# version of anthropics/claude-code-action/examples/issue-triage.yml —
-# the official example uses a `/label-issue` slash command requiring
-# `.claude/commands/label-issue.md` + a custom script. We skip that
-# and just inline the instructions; upgrade to a slash command later
-# if the prompt grows.
+# Single-shot label triage on new issues. Was on Anthropic
+# claude-code-action; swapped to MiniMax M2 because:
+#   - triage is text-in / labels-out, no agentic flow needed
+#   - cheap + frequent enough to matter at scale
+#
+# Logic:
+#   1. Fetch the new issue body + repo's existing label set.
+#   2. Ask MiniMax to pick 1–3 best-fit existing labels (NEVER invent new
+#      ones; that's a maintainer decision).
+#   3. Apply via the GitHub API.
+#
+# `@claude` mentions inside the issue body are still routed by claude.yml
+# (Anthropic) — that's the code-fixing path, separate concern.
 
 on:
   issues:
     types: [opened]
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
-  triage-issue:
+  triage:
+    name: MiniMax label-triage
     runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      contents: read
-      issues: write
+    timeout-minutes: 3
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 1
+      - name: Verify secret + mask
+        env:
+          K: ${{ secrets.MINIMAX_API_KEY }}
+        run: |
+          if [ -z "$K" ]; then
+            echo "::error::MINIMAX_API_KEY not set."
+            exit 1
+          fi
+          echo "::add-mask::$K"
 
-      - name: Run Claude Code for Issue Triage
-        uses: anthropics/claude-code-action@v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          # NOTE: with the default (allowed_non_write_users not set),
-          # only issues opened by users with write permission trigger
-          # this workflow. For a single-maintainer repo that's fine.
-          # If you start getting issues from outside contributors and
-          # want them auto-triaged too, add:
-          #   allowed_non_write_users: "*"
-          # but be aware that's the ⚠️ RISKY input — combined with the
-          # strict --allowedTools below it's bounded, but think before
-          # flipping it on.
-          prompt: |
-            REPO: ${{ github.repository }}
-            ISSUE: ${{ github.event.issue.number }}
+      - name: Fetch issue + repo labels
+        id: ctx
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          ISSUE: ${{ github.event.issue.number }}
+        run: |
+          curl -sS \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/$REPO/issues/$ISSUE" \
+            | jq -r '{title: .title, body: .body, author: .user.login}' \
+            > issue.json
 
-            Triage this newly-opened issue. Steps:
+          # Get all repo labels (paginated; bump if you have >100).
+          curl -sS \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/$REPO/labels?per_page=100" \
+            | jq -r '[.[] | {name: .name, description: .description}]' \
+            > labels.json
 
-            1. Read the issue body and title with `gh issue view ${{ github.event.issue.number }}`.
-            2. List existing repo labels with `gh label list`.
-            3. Apply the 1–3 most relevant existing labels using
-               `gh issue edit ${{ github.event.issue.number }} --add-label "<name>"`.
-            4. Do NOT create new labels. If no existing label fits, leave
-               it unlabeled.
-            5. Do NOT post a triage comment unless the issue is missing
-               critical info (no repro steps for a bug, no version, etc.)
-               in which case post one short comment asking for it.
+      - name: Build prompt
+        run: |
+          cat > /tmp/build.py <<'PY'
+          import json
+          with open("issue.json") as f: i = json.load(f)
+          with open("labels.json") as f: lbls = json.load(f)
+          label_lines = "\n".join(
+              f"- `{x['name']}`" + (f": {x['description']}" if x.get('description') else "")
+              for x in lbls
+          )
+          prompt = f"""You are triaging a newly-opened GitHub issue on the **twitter-mcp** repo.
 
-            Keep it terse — labels first, words last.
-          claude_args: |
-            --allowedTools "Bash(gh label list:*),Bash(gh issue view:*),Bash(gh issue edit:*),Bash(gh issue comment:*)"
+          Existing labels (you MUST pick from these — do NOT invent new labels):
+          {label_lines}
+
+          Issue title: {i.get('title','')}
+          Issue author: @{i.get('author','?')}
+
+          Issue body:
+          ---
+          {i.get('body') or '(empty)'}
+          ---
+
+          ## Output format — STRICT JSON
+
+          Respond with a single JSON object (no markdown wrap, no prose):
+          {{
+            "labels": ["pick", "1–3", "best-fit", "labels", "from", "the", "list", "above"],
+            "needs_more_info": true | false,
+            "info_request": "if needs_more_info=true, one short comment asking for what's missing (e.g. 'Please share the twikit version + a reproducer.'). Otherwise empty string."
+          }}
+
+          Rules:
+          - `labels`: pick 1–3 labels that genuinely apply. If nothing fits, return empty array `[]`.
+          - `needs_more_info`: true ONLY for bug reports missing repro / version / log. Don't use for feature requests.
+          - Be terse — labels first, words last."""
+          with open("prompt.txt", "w") as f: f.write(prompt)
+          PY
+          python3 /tmp/build.py
+
+      - name: Call MiniMax M2 (JSON mode)
+        id: call
+        env:
+          K: ${{ secrets.MINIMAX_API_KEY }}
+        run: |
+          payload=$(jq -nc --rawfile p prompt.txt \
+            '{
+              model: "MiniMax-M2",
+              messages: [{role: "user", content: $p}],
+              max_tokens: 2000,
+              temperature: 0.1,
+              response_format: {type: "json_object"}
+            }')
+
+          http=$(curl -sS -o response.json -w '%{http_code}' \
+            --max-time 60 \
+            https://api.minimaxi.com/v1/chat/completions \
+            -H "Authorization: Bearer $K" \
+            -H "Content-Type: application/json" \
+            -d "$payload")
+          echo "http=$http" >> "$GITHUB_OUTPUT"
+
+          if [ "$http" != "200" ]; then
+            echo "::warning::MiniMax HTTP $http; triage skipped."
+            head -c 1000 response.json
+            exit 0
+          fi
+
+      - name: Parse + apply
+        if: steps.call.outputs.http == '200'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          ISSUE: ${{ github.event.issue.number }}
+        run: |
+          jq -r '.choices[0].message.content // empty' response.json > raw.md
+
+          cat > /tmp/parse.py <<'PY'
+          import json, re, sys
+          src = sys.stdin.read()
+          src = re.sub(r"<think>.*?</think>", "", src, flags=re.DOTALL)
+          src = re.sub(r"<think>.*$", "", src, flags=re.DOTALL)
+          m = re.search(r"\{.*\}", src, re.DOTALL)
+          if not m:
+              print("ERR: no JSON object", file=sys.stderr); sys.exit(1)
+          parsed = json.loads(m.group(0))
+          parsed.setdefault("labels", [])
+          parsed.setdefault("needs_more_info", False)
+          parsed.setdefault("info_request", "")
+          json.dump(parsed, sys.stdout)
+          PY
+          python3 /tmp/parse.py < raw.md > triage.json
+          cat triage.json | jq .
+
+          # Apply labels (if any).
+          labels=$(jq -c '.labels' triage.json)
+          if [ "$labels" != "[]" ] && [ "$labels" != "null" ]; then
+            curl -sS -X POST \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              -d "{\"labels\": $labels}" \
+              "https://api.github.com/repos/$REPO/issues/$ISSUE/labels" \
+              -o /dev/null \
+              -w "Applied labels → HTTP %{http_code}\n"
+          else
+            echo "No labels selected."
+          fi
+
+          # Info-request comment (only if needed).
+          needs=$(jq -r '.needs_more_info' triage.json)
+          if [ "$needs" = "true" ]; then
+            req=$(jq -r '.info_request' triage.json)
+            if [ -n "$req" ] && [ "$req" != "null" ]; then
+              jq -nc --arg b "$req" '{body: $b}' > /tmp/comment.json
+              curl -sS -X POST \
+                -H "Authorization: Bearer $GH_TOKEN" \
+                -H "Accept: application/vnd.github+json" \
+                -d @/tmp/comment.json \
+                "https://api.github.com/repos/$REPO/issues/$ISSUE/comments" \
+                -o /dev/null \
+                -w "Posted info-request → HTTP %{http_code}\n"
+            fi
+          fi

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,22 +1,20 @@
 name: PR review (MiniMax M2)
 
 # Per-PR automated review by MiniMax M2 via OpenAI-compatible
-# api.minimaxi.com endpoint. Replaces the previous anthropics/claude-code-action
-# version (which lived in PR #21 → reverted here in this PR).
+# api.minimaxi.com endpoint. Originally swapped in via PR #42 (replacing
+# anthropics/claude-code-action). Major v2 changes (this revision):
 #
-# Why MiniMax for review specifically:
-#   - review is the highest-frequency LLM call in this repo (every PR
-#     open/synchronize), and tokens add up; M2 is ~1/10th the cost of
-#     Sonnet for comparable summarisation/critique quality.
-#   - review only needs text-out (no tool use), which the OpenAI-compat
-#     endpoint covers fine.
+#   1. JSON-mode output (`response_format: {"type": "json_object"}`) so
+#      the Decision is a top-level field — no more grep-the-markdown.
+#   2. Post-review action: when decision is `request-changes`, auto-summon
+#      `@claude` with iter cap of 5 + escalation issue (.github/scripts/
+#      auto_summon_claude.sh handles the cap logic).
+#   3. When decision is `approve`/`comment`, enable GitHub native
+#      auto-merge — the PR merges as soon as required CI checks pass.
 #
 # `@claude` mentions in `claude.yml` stay on Anthropic — those need
-# Claude Code's tool-using session to actually edit files / commit / push,
-# which M2 has no equivalent for via curl.
-#
-# Endpoint + model id pinned via PR #41's probe; see that PR's body for
-# the captured response shape if a future model upgrade changes things.
+# Claude Code's tool-using session to actually edit/commit/push, which
+# OpenAI-compat M2 has no equivalent for.
 
 on:
   pull_request:
@@ -30,6 +28,7 @@ concurrency:
 permissions:
   contents: read
   pull-requests: write
+  issues: write   # used by auto_summon_claude.sh to open escalation issues
 
 jobs:
   review:
@@ -40,9 +39,6 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v4
-        # `gh pr diff <num>` calls the API directly — it doesn't need a
-        # local git history, so the default depth (1) suffices. Saves a
-        # few seconds per run.
         with:
           fetch-depth: 1
 
@@ -62,12 +58,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUM: ${{ github.event.pull_request.number }}
         run: |
-          # Cap to 80 KB. M2 has plenty of context but the full prompt
-          # is diff + rubric + repo conventions; leave headroom and trim
-          # generated lockfiles where the LLM has nothing useful to say.
-          # Explicit lockfile list (not `.*\.lock$`, which would also
-          # eat any unrelated `*.lock` source file the project happens
-          # to have).
           gh pr diff "$PR_NUM" \
             | grep -vE '^(diff --git|---|\+\+\+) .*(/|^)(uv\.lock|package-lock\.json|pnpm-lock\.yaml|yarn\.lock|poetry\.lock|Gemfile\.lock|Cargo\.lock|composer\.lock)$' \
             | head -c 80000 > pr.diff
@@ -77,16 +67,13 @@ jobs:
             echo "skip=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Build prompt
+      - name: Build prompt (JSON output mode)
         if: steps.diff.outputs.skip != 'true'
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
-          # Persist PR body to a file separately — embedding it inline with
-          # echo / heredoc would break on backticks, $-prefixed strings, etc.
-          # `printf '%s'` prints the env var verbatim with no shell escapes.
           printf '%s' "$PR_BODY" > pr_body.txt
 
           {
@@ -115,30 +102,56 @@ jobs:
             cat pr.diff
             echo '```'
             echo
-            echo "## Output format"
-            echo "Output a concise markdown review with these sections (omit a section if empty):"
-            echo "- **Summary** (1-3 sentences: what does this PR do?)"
-            echo "- **Must-fix** (bugs, security holes, missing guards, broken tests)"
-            echo "- **Suggestions** (improvements that aren't blockers)"
-            echo "- **Nits** (style / naming / wording, no architectural impact)"
-            echo "- **Decision**: \`approve\` / \`comment\` / \`request-changes\`"
+            echo "## Output format — STRICT JSON"
             echo
-            echo "Cite specific lines as \`path/to/file.py:42\`. Be terse — under 600 words total. Skip generic praise. If you find no real issues, say so plainly."
+            echo "Respond with a single JSON object (no markdown wrapping, no extra text). Schema:"
+            echo
+            echo '```'
+            cat <<'JSON_SCHEMA'
+          {
+            "summary": "1–3 sentences: what does this PR do?",
+            "must_fix": [
+              {"file": "path/to/file.py", "line": 42, "issue": "what's broken / unsafe / missing"}
+            ],
+            "suggestions": [
+              {"file": "...", "line": 0, "issue": "..."}
+            ],
+            "nits": [
+              {"file": "...", "line": 0, "issue": "..."}
+            ],
+            "decision": "approve | comment | request-changes"
+          }
+          JSON_SCHEMA
+            echo '```'
+            echo
+            echo "**Decision rules** (very important):"
+            echo "- \`approve\`: nothing must-fix; suggestions and nits are optional polish."
+            echo "- \`comment\`: nothing must-fix, but you have suggestions worth seeing — DEFAULT for non-trivial PRs."
+            echo "- \`request-changes\`: at least one entry in \`must_fix\` AND it's a real bug / security hole / broken contract — NOT a stylistic preference."
+            echo
+            echo "Be **conservative** with \`request-changes\`. The auto-fix loop fires on it; false positives waste tokens. If you're unsure whether something is a real bug, put it in \`suggestions\` and pick \`comment\`."
+            echo
+            echo "Cite line numbers as integers from the diff. \`line: 0\` means file-level. Empty arrays where you have nothing to say. No prose outside the JSON."
           } > prompt.txt
 
-      - name: Call MiniMax M2
+      - name: Call MiniMax M2 (JSON mode)
         id: call
         if: steps.diff.outputs.skip != 'true'
         env:
           K: ${{ secrets.MINIMAX_API_KEY }}
         run: |
-          # max_tokens covers BOTH the visible review AND the hidden
-          # reasoning block (M2's <think>…</think> spends 1-2 KB of tokens
-          # on a non-trivial diff). 4000 was too tight — reviews got
-          # truncated mid-Must-fix. 8000 leaves the visible portion
-          # comfortable.
+          # max_tokens covers reasoning + JSON output. M2 reasoning runs
+          # 1-2 KB on a substantive diff; 8000 leaves comfortable room.
+          # response_format: {"type": "json_object"} forces the model to
+          # emit valid JSON (OpenAI-compat semantics).
           payload=$(jq -nc --rawfile p prompt.txt \
-            '{model:"MiniMax-M2", messages:[{role:"user", content:$p}], max_tokens:8000, temperature:0.2}')
+            '{
+              model: "MiniMax-M2",
+              messages: [{role: "user", content: $p}],
+              max_tokens: 8000,
+              temperature: 0.2,
+              response_format: {type: "json_object"}
+            }')
 
           http=$(curl -sS -o response.json -w '%{http_code}' \
             --max-time 180 \
@@ -155,11 +168,11 @@ jobs:
             exit 0
           fi
 
-      - name: Extract review (strip <think> reasoning block)
+      - name: Parse JSON output (strip <think> defensively)
+        id: parse
         if: steps.diff.outputs.skip != 'true' && steps.call.outputs.http == '200'
         run: |
-          # Save raw model content first — used to extract review and to
-          # dump unaltered into the step summary for debugging.
+          # Save raw model content first.
           jq -r '.choices[0].message.content // empty' response.json > raw.md
 
           if [ ! -s raw.md ]; then
@@ -167,47 +180,95 @@ jobs:
             exit 0
           fi
 
-          # M2 emits visible reasoning between <think>...</think>. Strip
-          # every such block — single-line, multi-line, repeated, and
-          # unclosed (when max_tokens cuts off mid-reasoning).
-          #
-          # NOTE on shell plumbing: `python3 - <<'PY' < raw.md > review.md`
-          # CAN'T be used here. Bash treats both `<<'PY'` and `< raw.md` as
-          # stdin redirections; the later one wins, so python ends up
-          # reading raw.md as if it were Python source (SyntaxError). Pass
-          # the script via `-c` instead and pipe stdin separately.
-          python3 -c '
-          import re, sys
+          # Heredoc-to-file pattern — single-quoted PY delimiter means bash
+          # doesn't touch the body, so the python source can use any quotes
+          # it needs without escape gymnastics.
+          cat > /tmp/parse.py <<'PY'
+          import json, re, sys
           src = sys.stdin.read()
+          # Even in JSON mode, M2 may emit a <think>...</think> reasoning
+          # block before the JSON object. Strip closed and unclosed forms.
           src = re.sub(r"<think>.*?</think>", "", src, flags=re.DOTALL)
           src = re.sub(r"<think>.*$", "", src, flags=re.DOTALL)
-          sys.stdout.write(src.strip() + "\n")
-          ' < raw.md > review.md
+          # Extract the first {...} block (model may still wrap with prose).
+          m = re.search(r"\{.*\}", src, re.DOTALL)
+          if not m:
+              print("ERR: no JSON object in response", file=sys.stderr)
+              sys.exit(1)
+          parsed = json.loads(m.group(0))
+          # Defaults — model occasionally omits empty arrays.
+          parsed.setdefault("summary", "(no summary)")
+          parsed.setdefault("must_fix", [])
+          parsed.setdefault("suggestions", [])
+          parsed.setdefault("nits", [])
+          parsed.setdefault("decision", "comment")
+          # Defensive: clamp decision to known enum.
+          if parsed["decision"] not in ("approve", "comment", "request-changes"):
+              parsed["decision"] = "comment"
+          json.dump(parsed, sys.stdout, indent=2)
+          PY
+          python3 /tmp/parse.py < raw.md > review.json
 
-          # Defensive: never post empty.
-          if [ ! -s review.md ]; then
-            echo "Review file empty after strip; falling back to raw content." >&2
-            cp raw.md review.md
-          fi
+          decision=$(jq -r '.decision' review.json)
+          echo "decision=$decision" >> "$GITHUB_OUTPUT"
+          echo "Decision: $decision"
 
-      - name: Capture token usage + raw model output for the run summary
+      - name: Render review.md from JSON
+        if: steps.diff.outputs.skip != 'true' && steps.call.outputs.http == '200' && steps.parse.outputs.decision != ''
+        run: |
+          cat > /tmp/render.py <<'PY'
+          import json
+          with open("review.json") as f:
+              r = json.load(f)
+          out = ["**Summary:** " + r["summary"]]
+          for section, label in [("must_fix", "Must-fix"),
+                                 ("suggestions", "Suggestions"),
+                                 ("nits", "Nits")]:
+              items = r.get(section) or []
+              if not items:
+                  continue
+              out.append("")
+              out.append(f"## {label}")
+              for it in items:
+                  loc = it.get("file", "?")
+                  ln = it.get("line", 0) or 0
+                  if ln > 0:
+                      loc = f"{loc}:{ln}"
+                  msg = (it.get("issue") or "").strip()
+                  out.append(f"- `{loc}` — {msg}")
+          out.append("")
+          out.append(f"**Decision:** `{r['decision']}`")
+          print("\n".join(out))
+          PY
+          python3 /tmp/render.py > review.md
+
+      - name: Capture token usage + raw output for the run summary
         if: steps.diff.outputs.skip != 'true' && steps.call.outputs.http == '200'
         run: |
           usage=$(jq -c '.usage // {}' response.json)
           {
             echo "## MiniMax review"
             echo
+            echo "Decision: \`${{ steps.parse.outputs.decision }}\`"
             echo "Token usage: \`$usage\`"
             echo
-            echo "### Posted review (after \`<think>\` strip)"
+            echo "### Posted review"
             echo
             cat review.md
             echo
             echo
-            echo "<details><summary>Raw model content (with <think> reasoning, debug only)</summary>"
+            echo "<details><summary>Parsed JSON (debug)</summary>"
+            echo
+            echo '```json'
+            cat review.json
             echo
             echo '```'
-            # Truncate raw to 16 KB to keep summary readable on a wide diff.
+            echo
+            echo "</details>"
+            echo
+            echo "<details><summary>Raw model content (with <think>, debug)</summary>"
+            echo
+            echo '```'
             head -c 16000 raw.md
             echo
             echo '```'
@@ -215,8 +276,8 @@ jobs:
             echo "</details>"
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Post review as PR comment
-        if: steps.diff.outputs.skip != 'true' && steps.call.outputs.http == '200'
+      - name: Post review comment
+        if: steps.diff.outputs.skip != 'true' && steps.call.outputs.http == '200' && steps.parse.outputs.decision != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUM: ${{ github.event.pull_request.number }}
@@ -227,7 +288,36 @@ jobs:
             cat review.md
             echo
             echo "---"
-            echo "_Automated review. For deeper changes that need code edits, mention \`@claude\` to invoke a tool-using Anthropic session._"
+            echo "_Automated review. \`request-changes\` triggers an auto-fix loop (cap 5); \`approve\` / \`comment\` triggers GitHub auto-merge once required CI checks are green._"
           } > final.md
 
           gh pr comment "$PR_NUM" --body-file final.md
+
+      # ─── Post-review action: auto-fix loop OR auto-merge ───
+      - name: Auto-summon @claude (decision = request-changes)
+        if: steps.parse.outputs.decision == 'request-changes'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+          REASON: "MiniMax review"
+          BODY_FILE: review.md
+        run: bash .github/scripts/auto_summon_claude.sh
+
+      - name: Enable GitHub auto-merge (decision = approve | comment)
+        if: steps.parse.outputs.decision == 'approve' || steps.parse.outputs.decision == 'comment'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+        run: |
+          # `gh pr merge --auto --squash` enables GitHub's native auto-merge.
+          # GH then merges the PR automatically once **all required checks**
+          # (per branch protection) are green. If branch protection isn't
+          # configured to require checks, this merges immediately — set
+          # protection on `main` if you want CI to gate.
+          #
+          # Idempotent: enabling auto-merge on an already-auto-mergeable PR
+          # is a no-op.
+          if ! gh pr merge --auto --squash "$PR_NUM" 2>&1; then
+            echo "::warning::auto-merge enable failed. Likely causes: (a) auto-merge disabled in repo Settings → General; (b) PR already in a state GH can't auto-merge; (c) branch protection misconfigured. Skipping — PR stays open for manual merge."
+          fi

--- a/tests/test_fixture_shapes.py
+++ b/tests/test_fixture_shapes.py
@@ -1,0 +1,88 @@
+"""Guard against mock-shape vs real-shape drift.
+
+If a test fake claims to mock a vendored twikit model, every attribute
+the fake defines MUST exist on the real model. Otherwise tests pass
+under mocks while production hits `AttributeError` on the real thing.
+
+Worked example: issue #37 — `_fake_user_full` defined
+`profile_image_url_https` (the JSON key shape), real `User` exposes
+`profile_image_url` (the normalized attribute name). All `get_user_info`
+mock tests passed; the first real X call from live-smoke crashed with
+``AttributeError: 'User' object has no attribute 'profile_image_url_https'``.
+
+This test would have caught that at PR time, before the bug shipped.
+"""
+
+import inspect
+import re
+
+import pytest
+
+from tests.test_tools import (
+    _fake_community,
+    _fake_community_member,
+    _fake_list,
+    _fake_tweet,
+    _fake_user,
+    _fake_user_full,
+)
+from twitter_mcp._vendor.twikit.community import Community, CommunityMember
+from twitter_mcp._vendor.twikit.list import List
+from twitter_mcp._vendor.twikit.tweet import Tweet
+from twitter_mcp._vendor.twikit.user import User
+
+
+def _accessible_attrs(cls) -> set[str]:
+    """All names a caller could read on an instance of `cls`.
+
+    Aggregates three sources (any one is enough to make the attribute
+    real and avoid AttributeError at runtime):
+
+      1. `self.X` assignments in `__init__` (direct fields).
+      2. `@property` decorated method names (computed accessors —
+         this is how `Tweet.text` / `Tweet.favorite_count` / etc. live).
+      3. Plain method names on the class (also accessible).
+
+    A regex on `inspect.getsource(cls)` covers all three; full AST
+    isn't worth the extra surface area for these flat, parse-style
+    twikit models.
+    """
+    src = inspect.getsource(cls)
+    fields = set(re.findall(r"self\.(\w+)\s*[:=]", src))
+    properties = set(re.findall(r"@property\s+def\s+(\w+)\s*\(", src))
+    methods = set(re.findall(r"^\s+def\s+(\w+)\s*\(", src, flags=re.MULTILINE))
+    return fields | properties | methods
+
+
+def _fake_attrs(factory) -> set[str]:
+    """Default-construct the fake and read back its SimpleNamespace fields."""
+    return set(vars(factory()))
+
+
+# (test_fake_factory, real_vendor_class) pairs.
+_PAIRS = [
+    ("_fake_user", _fake_user, User),
+    ("_fake_user_full", _fake_user_full, User),
+    ("_fake_tweet", _fake_tweet, Tweet),
+    ("_fake_list", _fake_list, List),
+    ("_fake_community", _fake_community, Community),
+    ("_fake_community_member", _fake_community_member, CommunityMember),
+]
+
+
+@pytest.mark.parametrize(
+    ("name", "factory", "real"),
+    [(n, f, r) for n, f, r in _PAIRS],
+    ids=[n for n, _, _ in _PAIRS],
+)
+def test_fake_attrs_are_subset_of_real(name, factory, real):
+    fake = _fake_attrs(factory)
+    real_set = _accessible_attrs(real)
+    extra = fake - real_set
+    assert not extra, (
+        f"Fake `{name}` defines attribute(s) {sorted(extra)} that don't exist on "
+        f"real `{real.__name__}`. This is the mock-vs-reality drift that bit issue #37 "
+        f"(`profile_image_url_https` vs `profile_image_url`). Either rename the field "
+        f"on the fake to match the real model, or remove it. Real model attributes:\n"
+        f"  {sorted(real_set)}"
+    )


### PR DESCRIPTION
## What this PR ships

End-to-end PR autonomy + the SDD guard that would've caught issue #37 at PR time. Three logical commits:

1. **`test: SDD guard — fixture attributes must be subset of real twikit model`** (`b915e86`)  
   New `tests/test_fixture_shapes.py`. Introspects every `_fake_*` factory in `test_tools.py` and asserts each field is accessible on the real vendored model (direct `self.X`, `@property`, or method). Catches the `profile_image_url_https` vs `profile_image_url` class of bug at PR time. 6 parametrised tests, all green.

2. **`feat: full PR autonomy — JSON review + 5-iter @claude loop + auto-merge`** (`efe855b`)  
   The big one. After merge, every PR runs:
   ```
   PR open → MiniMax JSON review
     → request-changes → @claude auto-fix (cap 5) → escalate to issue if cap hit
     → approve | comment → gh pr merge --auto --squash
                          → GitHub auto-merges when CI green
                          → push to main fires publish.yml → PyPI + GH Release
   ```
   Plus `ci-failure-auto-fix` job in `ci.yml` (shares the same iter cap when CI fails on a PR).  
   Plus `issue-triage.yml` rewritten to MiniMax (was Anthropic).

3. **`docs: PR template with SDD checklist (spec ↔ code sync gates)`** (`ca45ca3`)  
   `.github/PULL_REQUEST_TEMPLATE.md` with 5 spec-checklist boxes that map directly to the recurring drift modes.

## Architecture

| Stage | Workflow | LLM | Cap |
|---|---|---|---|
| PR review | `pr-review.yml` (rewritten) | MiniMax M2 (JSON mode) | per-PR review every push |
| CI failure handler | `ci.yml::ci-failure-auto-fix` (new) | summon @claude | 5-iter (shared with review) |
| Auto-fix bot | `claude.yml` (unchanged) | Anthropic Claude Code | (no cap; iter cap is on the summon side) |
| Issue triage | `issue-triage.yml` (rewritten) | MiniMax M2 (JSON mode) | none |
| Auto-merge | `pr-review.yml` post-step | n/a | once required CI green |
| Publish | `publish.yml` (unchanged) | n/a | once / version bump |
| Live-smoke loop | `live-smoke.yml` (unchanged) | summon @claude | per-SHA dedup |

## Implementation notes

- **`.github/scripts/auto_summon_claude.sh`** is the shared cap-aware summon helper. Both `pr-review.yml::request-changes` and `ci.yml::ci-failure-auto-fix` call it with `REASON` + `BODY_FILE`. Marker: `<!-- auto-fix-iter -->` (greppable, idempotent).
- **JSON-mode review prompt** asks for `{summary, must_fix[], suggestions[], nits[], decision}`. Decision enum is server-clamped to `{approve, comment, request-changes}` — model can't output garbage and break the auto-merge logic.
- **Conservative `request-changes`** — prompt explicitly tells the model "false positives waste tokens; default to `comment` if unsure". Fewer false summons.
- **Auto-merge** uses `gh pr merge --auto --squash`. GitHub waits for required checks per branch protection. **You should configure branch protection** on `main` requiring `Lint & Format`, `Test (Python 3.14, ubuntu-latest)`, `MCP Protocol Check` — otherwise auto-merge fires immediately even on red CI.

## Self-validating

This PR exercises the new `pr-review.yml` on itself. Expect a JSON-mode MiniMax review comment within ~20s of opening, with a clear Decision footer. If the review parses cleanly + decides `approve`/`comment` + CI all greens → it auto-merges itself.

## Test plan

- [x] `tests/test_fixture_shapes.py` — 6/6 green (catches the issue #37 class of bug)
- [x] Full suite — 488/488 pass; `twitter_mcp/server.py` 100% coverage; `--cov-fail-under=95` held
- [x] All 3 modified workflow files — `yaml.safe_load` clean
- [x] `auto_summon_claude.sh` — shellcheck-friendly, env-var-driven, no inline secrets
- [ ] CI green on PR
- [ ] **MiniMax JSON review fires on this PR itself** — confirms JSON parsing, decision rendering, post-action branch
- [ ] If approve/comment + CI green: **PR auto-merges** (the ultimate self-validation)

## Risks accepted (per discussion)

- Bot-opened fix PRs may pile up if MiniMax keeps requesting changes — mitigated by 5-iter cap + escalation issue + conservative prompt.
- Auto-merge could ship logic bugs that mocks pass for — mitigated by live-smoke #37 loop + immutable PyPI versions (yankable).
- Merge gate for vendor refresh changes still requires human eyes (not enforced by code; convention).

## Closes / refs

- Closes the manual gate in the PR-review workflow
- Builds on PR #38 (observability) + PR #39 (live-smoke auto-summon) + PR #42 (initial MiniMax review)
- Wires the SDD checklist that issue #37 + the recent #34 review feedback would've benefited from

https://claude.ai/code/session_01YZ5NXtFwvf3yybuRVSzvPY

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZ5NXtFwvf3yybuRVSzvPY)_