### PR TITLE
fix: auto-merge fallback to direct squash when --auto refused

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -304,20 +304,37 @@ jobs:
           BODY_FILE: review.md
         run: bash .github/scripts/auto_summon_claude.sh
 
-      - name: Enable GitHub auto-merge (decision = approve | comment)
+      - name: Enable auto-merge → fall back to direct merge (decision = approve | comment)
         if: steps.parse.outputs.decision == 'approve' || steps.parse.outputs.decision == 'comment'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUM: ${{ github.event.pull_request.number }}
         run: |
-          # `gh pr merge --auto --squash` enables GitHub's native auto-merge.
-          # GH then merges the PR automatically once **all required checks**
-          # (per branch protection) are green. If branch protection isn't
-          # configured to require checks, this merges immediately — set
-          # protection on `main` if you want CI to gate.
+          # GitHub's `--auto` flag only enables auto-merge if the PR has at
+          # least one *pending* required check (i.e. branch protection has
+          # required statuses configured AND at least one isn't green yet).
+          # When a repo has no branch protection (or no required statuses),
+          # `--auto` rejects with "Pull Request is in clean status" — there's
+          # nothing for it to wait on. In that case we fall back to a direct
+          # merge: if the PR is mergeable right now, just merge it.
           #
-          # Idempotent: enabling auto-merge on an already-auto-mergeable PR
-          # is a no-op.
-          if ! gh pr merge --auto --squash "$PR_NUM" 2>&1; then
-            echo "::warning::auto-merge enable failed. Likely causes: (a) auto-merge disabled in repo Settings → General; (b) PR already in a state GH can't auto-merge; (c) branch protection misconfigured. Skipping — PR stays open for manual merge."
+          # Either path is correct for a fully-autonomous flow:
+          #   - With protection + required checks → `--auto` enables, GH
+          #     merges later when checks pass. We can return immediately.
+          #   - Without protection → direct `--squash` merges right now.
+          #
+          # Both paths skip / warn instead of failing the workflow, since
+          # auto-merge is best-effort.
+          if gh pr merge --auto --squash --delete-branch "$PR_NUM" 2>&1; then
+            echo "Auto-merge enabled — GitHub will merge once required checks pass."
+            exit 0
           fi
+
+          echo "::notice::Auto-merge enable refused (likely: no pending required checks). Trying direct merge."
+
+          if gh pr merge --squash --delete-branch "$PR_NUM" 2>&1; then
+            echo "Direct merge succeeded — PR is now closed."
+            exit 0
+          fi
+
+          echo "::warning::Both auto-merge enable and direct merge failed. PR stays open for manual handling. Likely causes: (a) 'Allow auto-merge' disabled in repo Settings → General; (b) branch protection requires reviewers; (c) PR has merge conflicts."


### PR DESCRIPTION
## Why

PR #44 (autonomy canary) didn't auto-merge — the warning step in `pr-review.yml` fired with `auto-merge enable failed`. Root cause: `gh pr merge --auto` only enables when there's a **pending required check** to wait on. With no branch protection (or no required statuses configured), all checks settle into `success` state without ever being `required → pending`, so GH refuses `--auto` (nothing to wait for).

## The fix

Two-step fallback:

1. Try `gh pr merge --auto --squash`. **Correct** when branch protection gates with required checks — GH waits for all of them to pass, then merges.
2. If that fails, try plain `gh pr merge --squash`. **Correct** when no protection / no required statuses — merges immediately if PR is currently mergeable.
3. Only warn (not error) if both fail. Genuine blockers: requires reviewer, conflicts, etc.

Plus: `--delete-branch` on both calls so head branches are cleaned up post-merge (matches the existing repo "auto-delete head branches" setting; idempotent).

## Self-validating

If the new logic works, this PR merges itself. If it doesn't, the workflow's warning prints which path was tried + the failure reason, and we iterate.

## Spec / SDD checklist

- [x] No new MCP tool
- [x] No test fixture changes
- [x] No vendor patches
- [x] No live-smoke validators
- [x] Tool count unchanged

## Closes / refs

- Fixes the open issue from PR #44 (still in #44's review trail)
- PR #44 should manually merge as a one-off; from this PR forward, future approve/comment PRs auto-merge on the new fallback

https://claude.ai/code/session_01YZ5NXtFwvf3yybuRVSzvPY

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZ5NXtFwvf3yybuRVSzvPY)_