### PR TITLE
feat: dual MCP+CLI in API docs + dedicated cli.md page + bump v0.1.22

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,116 @@
+# CLI mode
+
+`twikit-mcp` is a dual-mode binary: same install, two transports.
+
+| Mode | Command | When |
+|---|---|---|
+| **MCP server** (default) | `twikit-mcp` or `twikit-mcp serve` | Inside an AI agent (Claude Code, Cursor, Cline, …). The LLM sends JSON-RPC over stdio. |
+| **CLI** | `twikit-mcp list` / `twikit-mcp call <tool> …` | Shell scripts, automation, debugging. |
+
+Both modes share the same cookies file (`~/.config/twitter-mcp/cookies.json`) and the same 57 tools.
+
+## Subcommands
+
+### `serve` (default)
+
+Run the MCP server over stdio. This is the default when no subcommand is given — every existing `mcp.json` / Claude Code / Cursor config keeps working unchanged.
+
+```bash
+twikit-mcp           # default — MCP server
+twikit-mcp serve     # explicit, same behavior
+```
+
+Reads `~/.config/twitter-mcp/cookies.json` (or wherever `TWITTER_COOKIES` env var points). Speaks JSON-RPC 2.0 on stdin/stdout.
+
+### `list`
+
+Print the names of all registered MCP tools, one per line, sorted.
+
+```bash
+$ twikit-mcp list
+add_list_member
+block_user
+bookmark_tweet
+…
+unmute_user
+vote
+```
+
+Useful in scripts: `twikit-mcp list | grep ^get_` to find every read-only tool.
+
+### `call <tool> [key=value …]`
+
+Invoke one tool from the shell and print its JSON output to stdout. Args use `key=value` form; the tool's Python signature drives type coercion.
+
+```bash
+$ twikit-mcp call get_user_info screen_name=elonmusk
+{"id":"44196397","screen_name":"elonmusk","name":"Elon Musk", …}
+
+$ twikit-mcp call search_tweets query=AI count=5 product=Top
+[…]
+
+$ twikit-mcp call get_tweet tweet_id=20 | jq .text
+"just setting up my twttr"
+```
+
+#### Type coercion
+
+CLI args are always strings; we cast them to the tool's annotated types:
+
+| Annotation | Coercion | Examples |
+|---|---|---|
+| `str` | passthrough | `text="hello world"` |
+| `int` | `int(value)` | `count=5` |
+| `float` | `float(value)` | (rare in this project) |
+| `bool` | loose: `true / 1 / yes / on` (case-insensitive) → `True`, anything else → `False` | `is_private=true` |
+| `Optional[X]` / `X \| None` | unwrap to `X`; **empty string → `None`** explicitly | `cursor=` (forces None) |
+| Anything else | passthrough as raw string | (tool's own validation runs next) |
+
+#### KV splitting
+
+Each `key=value` token is split on the **first** `=` only. URLs, base64 strings, JWT tokens with extra `=` survive intact:
+
+```bash
+twikit-mcp call get_tweet tweet_id="https://x.com/user/status/1234567890"
+```
+
+#### Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Success — tool returned, JSON written to stdout. |
+| `1` | Argparse / shell-level error (e.g. missing required arg, bad subcommand). |
+| `2` | `ToolError` — tool's own validation rejected the input or the underlying twikit call typed an exception (`TooManyRequests`, `NotFound`). Error message goes to stderr. |
+| Other | Uncaught exception. Indicates a bug; please file an issue with the traceback. |
+
+## Tips
+
+### Pipe to `jq`
+
+The output is always valid JSON, so `jq` works natively:
+
+```bash
+twikit-mcp call get_user_info screen_name=elonmusk | jq .followers_count
+
+# follower count of every user in a list
+twikit-mcp call get_user_info screen_name=elonmusk | jq '.followers_count, .following_count'
+```
+
+### Cron a scheduled poll
+
+```bash
+# Every Monday 10:00, snapshot trending topics
+0 10 * * 1   /usr/local/bin/twikit-mcp call get_trends category=trending count=20 \
+             > "$HOME/trends/$(date +%F).json"
+```
+
+### Discover a tool's args
+
+The CLI lists valid args when you give an unknown one:
+
+```bash
+$ twikit-mcp call get_user_info bogus=x
+Unknown arg `bogus` for tool `get_user_info`. Valid args: ['screen_name', 'user_id']
+```
+
+For deeper help — including full docstrings + return shape — see the [MCP Tools API reference](api.md), which is auto-generated from the same docstrings the LLM sees over MCP.

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,8 @@ An [MCP](https://modelcontextprotocol.io/) server that lets Claude (or any MCP-c
 
 ## Where to go next
 
-- **[MCP Tools API](api.md)** — auto-generated reference of all 57 tools, with arg signatures and behavior. Read this if you want to know what a specific tool does.
+- **[MCP Tools API](api.md)** — auto-generated reference of all 57 tools, with **MCP and CLI usage** side by side for each tool. Read this when you want to know what a specific tool does.
+- **[CLI mode](cli.md)** — the same `twikit-mcp` binary as a one-shot CLI. Subcommands, type coercion, exit codes, examples.
 - **[Technical design](TECHNICAL.md)** — how the server works internally, how tool output shapes are kept compact, etc.
 - **[Vendoring twikit](VENDORING.md)** — every patch applied to the vendored copy, with the issue that motivated it.
 - **[Repo on GitHub](https://github.com/tangivis/twitter-mcp)** — README has install / quickstart in English / 中文 / 日本語.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,6 +83,7 @@ markdown_extensions:
 
 nav:
   - Home: index.md
+  - CLI mode: cli.md
   - MCP Tools API: api.md
   - Internals:
       - Technical design: TECHNICAL.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "twikit-mcp"
-version = "0.1.21"
+version = "0.1.22"
 description = "Twitter/X MCP server powered by twikit — no API key needed, free forever"
 readme = "README.md"
 license = "MIT"

--- a/scripts/gen_api_docs.py
+++ b/scripts/gen_api_docs.py
@@ -5,10 +5,12 @@ mkdocs build, has access to the project's Python environment (i.e.
 `twitter_mcp.server` is importable).
 
 Output: a single markdown page that groups all 57 MCP tools by their
-implicit category (read / write / list / community / dm / etc.) and
-emits one mkdocstrings `:::` directive per tool. mkdocstrings then
-resolves each ref into a heading + signature + docstring at render
-time — no need to commit the rendered file.
+implicit category (read / write / list / community / dm / etc.). For
+each tool we render the same source-of-truth docstring twice:
+
+  - As **MCP usage** (how an AI agent invokes it)
+  - As **CLI usage** (`twikit-mcp call <tool> key=value …`) for shell
+    scripts and debugging — same arg names, same behavior.
 
 We don't hand-write `api.md` because the tool set changes on most PRs
 and a hand-written file always drifts.
@@ -73,18 +75,70 @@ def _categorize(name: str) -> str:
     return "Other"
 
 
+def _annotation_str(ann) -> str:
+    """Render a Python annotation in a way close to source form."""
+    if ann is inspect.Parameter.empty:
+        return ""
+    if hasattr(ann, "__name__"):
+        return ann.__name__
+    return str(ann).replace("typing.", "")
+
+
 def _signature_str(fn) -> str:
-    """Render a one-line type-annotated signature, no `self` / decorator clutter."""
+    """One-line type-annotated signature, no `self` / decorator clutter."""
     sig = inspect.signature(fn)
-    params = []
+    parts = []
     for p in sig.parameters.values():
-        if p.annotation is inspect.Parameter.empty:
-            ann = ""
-        else:
-            ann = f": {p.annotation.__name__ if hasattr(p.annotation, '__name__') else p.annotation}"
+        ann = _annotation_str(p.annotation)
+        ann_part = f": {ann}" if ann else ""
         default = "" if p.default is inspect.Parameter.empty else f" = {p.default!r}"
-        params.append(f"{p.name}{ann}{default}")
-    return f"({', '.join(params)})"
+        parts.append(f"{p.name}{ann_part}{default}")
+    return f"({', '.join(parts)})"
+
+
+def _cli_example(name: str, fn) -> str:
+    """Build a `twikit-mcp call <name> key=value` example.
+
+    Pick required params (no default) + a couple of common optional ones,
+    using a placeholder that hints at the expected type. The user-visible
+    intent: 'show me what a real CLI invocation looks like'.
+    """
+    sig = inspect.signature(fn)
+    args = []
+    for p in sig.parameters.values():
+        # Required params: always include. Otherwise: cap at 2 optional
+        # examples so the line stays scannable.
+        is_required = p.default is inspect.Parameter.empty
+        if not is_required and len([a for a in args if a]) >= 2:
+            break
+
+        ann = _annotation_str(p.annotation)
+        # Choose a placeholder that hints at the type without being
+        # cute. Real users substitute their own values.
+        if "int" in ann.lower():
+            placeholder = "5" if "count" in p.name else "100"
+        elif "bool" in ann.lower():
+            placeholder = "true"
+        elif p.name in ("screen_name", "user"):
+            placeholder = "elonmusk"
+        elif p.name in ("tweet_id", "id"):
+            placeholder = "20"
+        elif p.name in ("query",):
+            placeholder = '"AI"'
+        elif p.name == "list_id":
+            placeholder = "1234567890"
+        elif p.name == "community_id":
+            placeholder = "1234567890"
+        elif p.name == "text":
+            placeholder = '"hello world"'
+        else:
+            placeholder = f"<{p.name}>"
+
+        args.append(f"{p.name}={placeholder}")
+
+    # If a tool is parameterless (rare), we still want a clean example.
+    arg_part = " " + " ".join(args) if args else ""
+    return f"twikit-mcp call {name}{arg_part}"
 
 
 tools = mcp._tool_manager._tools
@@ -112,13 +166,21 @@ with mkdocs_gen_files.open("api.md", "w") as f:
     f.write(
         "Auto-generated from the `@mcp.tool()`-decorated functions in "
         "`twitter_mcp.server` at docs build time. Total: "
-        f"**{len(tools)} tools**.\n\n"
+        f"**{len(tools)} tools**. Each tool is documented once below "
+        "with both invocation forms.\n\n"
+    )
+    f.write(
+        "| Form | When to use |\n"
+        "|---|---|\n"
+        "| **MCP** | Inside an AI agent (Claude Code, Cursor, etc.) — the LLM picks the tool and fills args from your prompt. |\n"
+        "| **CLI** | Shell scripts, debugging, automations. `twikit-mcp call <tool> key=value …` — same arg names, types coerced from strings. |\n\n"
     )
     f.write(
         "Tool docstrings are the source of truth — if a section here "
         "looks wrong, fix the docstring in `twitter_mcp/server.py` and "
         "the next docs build will catch up.\n\n"
     )
+    f.write("---\n\n")
 
     for section in SECTION_ORDER:
         names = by_section.get(section, [])
@@ -130,12 +192,25 @@ with mkdocs_gen_files.open("api.md", "w") as f:
             # Pull the underlying fn off twikit/FastMCP's wrapper if needed.
             fn = getattr(tool, "fn", None) or getattr(tool, "func", None) or tool
             f.write(f"### `{name}`\n\n")
+
+            # Signature block.
             try:
                 f.write(f"```python\n{name}{_signature_str(fn)}\n```\n\n")
             except (ValueError, TypeError):
                 pass
+
+            # Docstring.
             doc = inspect.getdoc(fn) or "_(no docstring)_"
             f.write(doc + "\n\n")
+
+            # CLI usage example.
+            try:
+                cli = _cli_example(name, fn)
+                f.write("**CLI:**\n\n")
+                f.write(f"```bash\n{cli}\n```\n\n")
+            except (ValueError, TypeError):
+                pass
+
             f.write("---\n\n")
 
     # Catch any tool that didn't fit a section — surface so we tweak


### PR DESCRIPTION
## Summary

Three small things in one PR — all required for the **0.1.22 release that publishes CLI + docs site to PyPI**.

| Change | Where | What |
|---|---|---|
| Dual MCP+CLI usage per tool | `scripts/gen_api_docs.py` | Every tool entry on the auto-generated API page now ends with a `twikit-mcp call <tool> key=value …` example, with hint-typed placeholders picked from the tool's signature. |
| Dedicated CLI page | `docs/cli.md` (new) + `mkdocs.yml` nav | Subcommand semantics, type coercion table, kv split on first `=`, exit codes (0/1/2), tips (jq pipe, cron, arg discovery). |
| Version bump | `pyproject.toml` | 0.1.21 → 0.1.22. `publish.yml` on merge to main triggers PyPI publish + tag + GH Release. |

## What ships in 0.1.22 (since last release 0.1.21)

- PR #43 — full PR autonomy chain (JSON review + 5-iter @claude loop + auto-merge)
- PR #45 — auto-merge fallback when `--auto` refused
- PR #46 — `contents: write` permission so workflow merge actually pushes
- PR #47 — GitHub Pages docs site (already deployed; this PR enriches the API page)
- PR #48 — CLI mode (`twikit-mcp call/list/serve`)
- This PR — CLI usage in docs + version bump

## Self-validating

The new pr-review chain handles this PR. Expected: review = `comment` (no must-fix), CI green, auto-merge fires, push to main triggers `publish.yml` + the docs deploy.

## Manual steps for you (one-time, won't auto-fix)

After this PR merges:

1. **Verify Pages is live**: `https://tangivis.github.io/twitter-mcp/` should show the docs site. If not, trigger Actions → "Docs (GitHub Pages)" → Run workflow.

2. **Set repo About section**: repo home → ⚙️ next to "About":
   - Website: `https://tangivis.github.io/twitter-mcp/`
   - Description: `Twitter/X MCP server + CLI — no API key needed. 57 tools across reads/writes/lists/communities/DMs.`
   - Tick "Use your GitHub Pages website" to keep them synced

MCP tooling doesn't expose repo-edit endpoints, so this is the only thing I can't do for you.

## Test plan

- [x] 521 tests pass; `twitter_mcp/server.py` 100% coverage; `--cov-fail-under=95` held
- [x] Local `mkdocs build` succeeds; api page renders with CLI block per tool
- [x] ruff format + ruff check clean
- [ ] CI green on PR
- [ ] MiniMax decision = `comment` or `approve` → auto-merge
- [ ] After merge: publish.yml ships PyPI 0.1.22 + GH Release v0.1.22 + tag; docs.yml redeploys site with new CLI examples

## Spec / SDD checklist

- [x] No new MCP tool
- [x] No test fixture changes
- [x] No vendor patches
- [x] No live-smoke validators
- [x] Tool count unchanged (still 57)

https://claude.ai/code/session_01YZ5NXtFwvf3yybuRVSzvPY

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZ5NXtFwvf3yybuRVSzvPY)_