### PR TITLE
feat: PAT-backed auto-merge + uv tool install docs + tri-lingual docs site

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -313,7 +313,22 @@ jobs:
       - name: Enable auto-merge → fall back to direct merge (decision = approve | comment)
         if: steps.parse.outputs.decision == 'approve' || steps.parse.outputs.decision == 'comment'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # IMPORTANT: prefer MERGE_PAT over GITHUB_TOKEN for the merge.
+          #
+          # GitHub's anti-loop protection: pushes (and tag pushes) made by
+          # GITHUB_TOKEN do NOT trigger downstream workflows. So when this
+          # step uses GITHUB_TOKEN to merge, the resulting push to `main`
+          # is invisible to publish.yml — the new release never ships.
+          #
+          # MERGE_PAT (a fine-grained Personal Access Token with
+          # contents:write + pull_requests:write on this repo) bypasses
+          # that limit: PAT-initiated pushes DO cascade to publish.yml +
+          # docs.yml + ci.yml as expected.
+          #
+          # If the secret isn't set, fall back to GITHUB_TOKEN — merge
+          # still happens, just no downstream cascade. The maintainer
+          # would have to trigger publish.yml manually each release.
+          GH_TOKEN: ${{ secrets.MERGE_PAT || secrets.GITHUB_TOKEN }}
           PR_NUM: ${{ github.event.pull_request.number }}
         run: |
           # GitHub's `--auto` flag only enables auto-merge if the PR has at
@@ -324,13 +339,12 @@ jobs:
           # nothing for it to wait on. In that case we fall back to a direct
           # merge: if the PR is mergeable right now, just merge it.
           #
-          # Either path is correct for a fully-autonomous flow:
-          #   - With protection + required checks → `--auto` enables, GH
-          #     merges later when checks pass. We can return immediately.
-          #   - Without protection → direct `--squash` merges right now.
-          #
           # Both paths skip / warn instead of failing the workflow, since
           # auto-merge is best-effort.
+          if [ -z "${{ secrets.MERGE_PAT }}" ]; then
+            echo "::warning::MERGE_PAT not set; falling back to GITHUB_TOKEN. Downstream workflows (publish.yml / docs.yml) will NOT auto-trigger after merge — releases require a manual workflow_dispatch. See README for the one-time PAT setup."
+          fi
+
           if gh pr merge --auto --squash --delete-branch "$PR_NUM" 2>&1; then
             echo "Auto-merge enabled — GitHub will merge once required checks pass."
             exit 0

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ chmod 600 ~/.config/twitter-mcp/cookies.json
 
 Choose **one** of the following methods:
 
-**Option A: uvx** (recommended if you have [uv](https://docs.astral.sh/uv/))
+**Option A: uvx** — zero-install, fetches each call (slow first run, fast after; cache shared with other uv tools). Best for quick try-out.
 
 ```bash
 # Claude Code
@@ -65,7 +65,37 @@ claude mcp add twitter -s user \
 uvx twikit-mcp
 ```
 
-**Option B: pip**
+**Option B: `uv tool install`** *(recommended for daily use)* — pinned isolated venv, instant startup, simple upgrade path.
+
+```bash
+# Install once. Drops a `twikit-mcp` binary on PATH (~/.local/bin).
+uv tool install twikit-mcp
+
+# List your installed uv tools (sanity check)
+uv tool list
+
+# Upgrade when a new version ships
+uv tool upgrade twikit-mcp
+# Or upgrade ALL uv-tool-managed binaries at once:
+uv tool upgrade --all
+
+# Uninstall (clean removal of the venv + binary)
+uv tool uninstall twikit-mcp
+```
+
+Then register with Claude Code (uses the binary on PATH — no `uvx` prefix):
+
+```bash
+claude mcp add twitter -s user \
+  -e "TWITTER_COOKIES=$HOME/.config/twitter-mcp/cookies.json" \
+  -- twikit-mcp
+```
+
+The cookies file is **the same** as for every other option: `~/.config/twitter-mcp/cookies.json` (or wherever `TWITTER_COOKIES` env var points). `uv tool install` doesn't change where config lives — only where the *binary* lives.
+
+> uvx vs `uv tool install` quick rule: use **uvx** if you'll call it once or twice (e.g. one-off script). Use **`uv tool install`** if it's part of your dev workflow (e.g. wired into Claude Code daily) — startup is instant after the one-time install.
+
+**Option C: pip**
 
 ```bash
 pip install twikit-mcp
@@ -79,7 +109,7 @@ claude mcp add twitter -s user \
 TWITTER_COOKIES=~/.config/twitter-mcp/cookies.json twikit-mcp
 ```
 
-**Option C: pipx** (isolated install)
+**Option D: pipx** (isolated install — same idea as `uv tool install`, but with pipx)
 
 ```bash
 pipx install twikit-mcp
@@ -293,7 +323,7 @@ chmod 600 ~/.config/twitter-mcp/cookies.json
 
 选择以下 **任一** 方式：
 
-**方式 A: uvx**（推荐，需要安装 [uv](https://docs.astral.sh/uv/)）
+**方式 A: uvx** — 零安装,每次调用拉一份。第一次慢,之后用 cache,跟其他 uv 工具共享。适合临时试用。
 
 ```bash
 # Claude Code
@@ -305,7 +335,37 @@ claude mcp add twitter -s user \
 uvx twikit-mcp
 ```
 
-**方式 B: pip**
+**方式 B: `uv tool install`** *(日常使用推荐)* — 隔离 venv,启动瞬间,升级简单。
+
+```bash
+# 一次性安装,在 PATH 上注册一个 `twikit-mcp` 二进制(默认路径 ~/.local/bin)
+uv tool install twikit-mcp
+
+# 列出当前 uv 管理的工具(确认装上了)
+uv tool list
+
+# 有新版本时升级
+uv tool upgrade twikit-mcp
+# 或一键升级所有 uv 装的工具:
+uv tool upgrade --all
+
+# 卸载(连 venv 一起清掉)
+uv tool uninstall twikit-mcp
+```
+
+然后用 PATH 上的二进制注册到 Claude Code(不要再加 `uvx` 前缀):
+
+```bash
+claude mcp add twitter -s user \
+  -e "TWITTER_COOKIES=$HOME/.config/twitter-mcp/cookies.json" \
+  -- twikit-mcp
+```
+
+cookies 文件**位置不变** — 仍然是 `~/.config/twitter-mcp/cookies.json`(或者 `TWITTER_COOKIES` 环境变量指的地方)。`uv tool install` 只改变**二进制**的安装位置,不改 config 路径。
+
+> uvx vs `uv tool install` 的简单选择: 一次性 / 偶尔用 → **uvx**;天天接到 Claude Code 里用 → **`uv tool install`**(启动快很多)。
+
+**方式 C: pip**
 
 ```bash
 pip install twikit-mcp
@@ -319,7 +379,7 @@ claude mcp add twitter -s user \
 TWITTER_COOKIES=~/.config/twitter-mcp/cookies.json twikit-mcp
 ```
 
-**方式 C: pipx**（隔离安装）
+**方式 D: pipx**(隔离安装,跟 `uv tool install` 思路一样,但换工具)
 
 ```bash
 pipx install twikit-mcp
@@ -510,7 +570,7 @@ chmod 600 ~/.config/twitter-mcp/cookies.json
 
 以下の **いずれか** の方法を選んでください：
 
-**方法 A: uvx**（推奨、[uv](https://docs.astral.sh/uv/) が必要）
+**方法 A: uvx** — ゼロインストール、毎回フェッチ。初回のみ遅い、以降はキャッシュで高速。お試し向け。
 
 ```bash
 # Claude Code
@@ -522,7 +582,37 @@ claude mcp add twitter -s user \
 uvx twikit-mcp
 ```
 
-**方法 B: pip**
+**方法 B: `uv tool install`**（日常利用に推奨）— 専用 venv で隔離インストール、起動が瞬時、アップグレードも簡単。
+
+```bash
+# 一度だけインストール。PATH (~/.local/bin) に `twikit-mcp` バイナリを配置
+uv tool install twikit-mcp
+
+# uv tool 管理下のツール一覧（確認用）
+uv tool list
+
+# 新バージョンが出たらアップグレード
+uv tool upgrade twikit-mcp
+# uv で入れた全ツールを一括アップグレード:
+uv tool upgrade --all
+
+# アンインストール（venv ごと削除）
+uv tool uninstall twikit-mcp
+```
+
+PATH 上のバイナリで Claude Code に登録（`uvx` プレフィックス不要）:
+
+```bash
+claude mcp add twitter -s user \
+  -e "TWITTER_COOKIES=$HOME/.config/twitter-mcp/cookies.json" \
+  -- twikit-mcp
+```
+
+cookies ファイルの場所は**他のオプションと同じ** — `~/.config/twitter-mcp/cookies.json` (もしくは `TWITTER_COOKIES` 環境変数)。`uv tool install` が変えるのは**バイナリの場所**だけで、設定ファイルの場所は変わりません。
+
+> uvx と `uv tool install` の使い分け: 一回だけ / たまに → **uvx**;Claude Code に組み込んで毎日使う → **`uv tool install`**(起動が圧倒的に速い)。
+
+**方法 C: pip**
 
 ```bash
 pip install twikit-mcp
@@ -536,7 +626,7 @@ claude mcp add twitter -s user \
 TWITTER_COOKIES=~/.config/twitter-mcp/cookies.json twikit-mcp
 ```
 
-**方法 C: pipx**（隔離インストール）
+**方法 D: pipx**（隔離インストール — `uv tool install` と同じ思想、ツール違い）
 
 ```bash
 pipx install twikit-mcp

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,50 +1,50 @@
 # CLI mode
 
+**[English](#english)** | **[中文](#zh)** | **[日本語](#ja)**
+
+---
+
+## English
+
 `twikit-mcp` is a dual-mode binary: same install, two transports.
 
 | Mode | Command | When |
 |---|---|---|
-| **MCP server** (default) | `twikit-mcp` or `twikit-mcp serve` | Inside an AI agent (Claude Code, Cursor, Cline, …). The LLM sends JSON-RPC over stdio. |
+| **MCP server** (default) | `twikit-mcp` or `twikit-mcp serve` | Inside an AI agent (Claude Code, Cursor, Cline, …). LLM sends JSON-RPC over stdio. |
 | **CLI** | `twikit-mcp list` / `twikit-mcp call <tool> …` | Shell scripts, automation, debugging. |
 
-Both modes share the same cookies file (`~/.config/twitter-mcp/cookies.json`) and the same 57 tools.
+Both share the same cookies file (`~/.config/twitter-mcp/cookies.json`) and the same 57 tools.
 
-## Subcommands
+### Subcommands
 
-### `serve` (default)
+#### `serve` (default)
 
-Run the MCP server over stdio. This is the default when no subcommand is given — every existing `mcp.json` / Claude Code / Cursor config keeps working unchanged.
+Run the MCP server over stdio. Default when no subcommand given — every existing `mcp.json` / Claude Code / Cursor config keeps working unchanged.
 
 ```bash
 twikit-mcp           # default — MCP server
-twikit-mcp serve     # explicit, same behavior
+twikit-mcp serve     # explicit
 ```
 
-Reads `~/.config/twitter-mcp/cookies.json` (or wherever `TWITTER_COOKIES` env var points). Speaks JSON-RPC 2.0 on stdin/stdout.
+#### `list`
 
-### `list`
-
-Print the names of all registered MCP tools, one per line, sorted.
+Print all registered tool names, sorted, one per line.
 
 ```bash
 $ twikit-mcp list
 add_list_member
 block_user
-bookmark_tweet
 …
-unmute_user
 vote
 ```
 
-Useful in scripts: `twikit-mcp list | grep ^get_` to find every read-only tool.
+#### `call <tool> [key=value …]`
 
-### `call <tool> [key=value …]`
-
-Invoke one tool from the shell and print its JSON output to stdout. Args use `key=value` form; the tool's Python signature drives type coercion.
+Invoke one tool, print its JSON output.
 
 ```bash
 $ twikit-mcp call get_user_info screen_name=elonmusk
-{"id":"44196397","screen_name":"elonmusk","name":"Elon Musk", …}
+{"id":"44196397","screen_name":"elonmusk", …}
 
 $ twikit-mcp call search_tweets query=AI count=5 product=Top
 […]
@@ -53,64 +53,218 @@ $ twikit-mcp call get_tweet tweet_id=20 | jq .text
 "just setting up my twttr"
 ```
 
-#### Type coercion
+### Type coercion
 
-CLI args are always strings; we cast them to the tool's annotated types:
+CLI args are strings; we cast to the tool's annotated types:
 
-| Annotation | Coercion | Examples |
-|---|---|---|
-| `str` | passthrough | `text="hello world"` |
-| `int` | `int(value)` | `count=5` |
-| `float` | `float(value)` | (rare in this project) |
-| `bool` | loose: `true / 1 / yes / on` (case-insensitive) → `True`, anything else → `False` | `is_private=true` |
-| `Optional[X]` / `X \| None` | unwrap to `X`; **empty string → `None`** explicitly | `cursor=` (forces None) |
-| Anything else | passthrough as raw string | (tool's own validation runs next) |
+| Annotation | Coercion |
+|---|---|
+| `str` | passthrough |
+| `int` / `float` | `int(value)` / `float(value)` |
+| `bool` | loose: `true / 1 / yes / on` (case-insensitive) → `True`; else `False` |
+| `Optional[X]` / `X \| None` | unwrap to `X`; **empty string → `None`** explicitly |
+| anything else | passthrough as raw string |
 
-#### KV splitting
+KV split is on the **first** `=` only — URLs / base64 / JWTs with extra `=` survive.
 
-Each `key=value` token is split on the **first** `=` only. URLs, base64 strings, JWT tokens with extra `=` survive intact:
-
-```bash
-twikit-mcp call get_tweet tweet_id="https://x.com/user/status/1234567890"
-```
-
-#### Exit codes
+### Exit codes
 
 | Code | Meaning |
 |---|---|
-| `0` | Success — tool returned, JSON written to stdout. |
-| `1` | Argparse / shell-level error (e.g. missing required arg, bad subcommand). |
-| `2` | `ToolError` — tool's own validation rejected the input or the underlying twikit call typed an exception (`TooManyRequests`, `NotFound`). Error message goes to stderr. |
-| Other | Uncaught exception. Indicates a bug; please file an issue with the traceback. |
+| `0` | Success |
+| `1` | Argparse / usage error |
+| `2` | `ToolError` (validation rejected the input or twikit raised typed exception) |
+| Other | Uncaught exception — bug, please file an issue |
 
-## Tips
-
-### Pipe to `jq`
-
-The output is always valid JSON, so `jq` works natively:
+### Tips
 
 ```bash
+# Pipe to jq
 twikit-mcp call get_user_info screen_name=elonmusk | jq .followers_count
 
-# follower count of every user in a list
-twikit-mcp call get_user_info screen_name=elonmusk | jq '.followers_count, .following_count'
-```
-
-### Cron a scheduled poll
-
-```bash
-# Every Monday 10:00, snapshot trending topics
+# Cron a snapshot
 0 10 * * 1   /usr/local/bin/twikit-mcp call get_trends category=trending count=20 \
              > "$HOME/trends/$(date +%F).json"
-```
 
-### Discover a tool's args
-
-The CLI lists valid args when you give an unknown one:
-
-```bash
+# Discover args via 'unknown arg' error
 $ twikit-mcp call get_user_info bogus=x
 Unknown arg `bogus` for tool `get_user_info`. Valid args: ['screen_name', 'user_id']
 ```
 
-For deeper help — including full docstrings + return shape — see the [MCP Tools API reference](api.md), which is auto-generated from the same docstrings the LLM sees over MCP.
+---
+
+## 中文 { #zh }
+
+`twikit-mcp` 是双模式二进制 — 同一个安装,两种调用方式。
+
+| 模式 | 命令 | 何时用 |
+|---|---|---|
+| **MCP server**(默认) | `twikit-mcp` 或 `twikit-mcp serve` | AI agent 里调用(Claude Code、Cursor、Cline 等),LLM 通过 stdio 发 JSON-RPC |
+| **CLI** | `twikit-mcp list` / `twikit-mcp call <tool> …` | shell 脚本、自动化、调试 |
+
+两种模式**共享同一个** cookies 文件(`~/.config/twitter-mcp/cookies.json`)和同样的 57 个工具。
+
+### 子命令
+
+#### `serve`(默认)
+
+跑 MCP server,通过 stdio 通信。不带子命令时默认走这个 — 现有所有 `mcp.json` / Claude Code / Cursor 配置都不用改。
+
+```bash
+twikit-mcp           # 默认 — MCP server
+twikit-mcp serve     # 显式
+```
+
+#### `list`
+
+打印所有注册过的工具名,排序后每行一个。
+
+```bash
+$ twikit-mcp list
+add_list_member
+block_user
+…
+vote
+```
+
+#### `call <tool> [key=value …]`
+
+调一个工具,打印 JSON 输出。
+
+```bash
+$ twikit-mcp call get_user_info screen_name=elonmusk
+{"id":"44196397","screen_name":"elonmusk", …}
+
+$ twikit-mcp call search_tweets query=AI count=5 product=Top
+[…]
+
+$ twikit-mcp call get_tweet tweet_id=20 | jq .text
+"just setting up my twttr"
+```
+
+### 类型转换
+
+CLI 传进来都是字符串,根据工具签名的标注 cast:
+
+| 标注 | 转换 |
+|---|---|
+| `str` | 直通 |
+| `int` / `float` | `int(value)` / `float(value)` |
+| `bool` | 宽松匹配:`true / 1 / yes / on`(不区分大小写)→ `True`;其他 → `False` |
+| `Optional[X]` / `X \| None` | 拆开取 `X`;**空字符串 → `None`**(显式 escape hatch) |
+| 其他 | 当字符串直通 |
+
+KV 切分**只切第一个 `=`** — URL / base64 / JWT 里的额外 `=` 完整保留。
+
+### 退出码
+
+| 码 | 含义 |
+|---|---|
+| `0` | 成功 |
+| `1` | argparse / 用法错误 |
+| `2` | `ToolError`(参数校验失败或 twikit 抛了类型化异常) |
+| 其他 | 未捕获异常 — bug,请提 issue |
+
+### Tips
+
+```bash
+# 管道接 jq
+twikit-mcp call get_user_info screen_name=elonmusk | jq .followers_count
+
+# cron 定期拍快照
+0 10 * * 1   /usr/local/bin/twikit-mcp call get_trends category=trending count=20 \
+             > "$HOME/trends/$(date +%F).json"
+
+# 通过"未知参数"报错查看可用 args
+$ twikit-mcp call get_user_info bogus=x
+Unknown arg `bogus` for tool `get_user_info`. Valid args: ['screen_name', 'user_id']
+```
+
+---
+
+## 日本語 { #ja }
+
+`twikit-mcp` はデュアルモードのバイナリです — 同じインストールで、2 つの利用方法。
+
+| モード | コマンド | 使う場面 |
+|---|---|---|
+| **MCP サーバー**(デフォルト) | `twikit-mcp` または `twikit-mcp serve` | AI エージェント(Claude Code、Cursor、Cline など)から呼び出し、LLM が stdio 経由で JSON-RPC を送る |
+| **CLI** | `twikit-mcp list` / `twikit-mcp call <tool> …` | シェルスクリプト、自動化、デバッグ |
+
+両モードとも**同じ cookies ファイル**(`~/.config/twitter-mcp/cookies.json`)と同じ 57 ツールを共有します。
+
+### サブコマンド
+
+#### `serve`(デフォルト)
+
+MCP サーバーを stdio で起動。サブコマンドなしのデフォルト動作 — 既存の `mcp.json` / Claude Code / Cursor 設定はそのまま動きます。
+
+```bash
+twikit-mcp           # デフォルト — MCP サーバー
+twikit-mcp serve     # 明示的
+```
+
+#### `list`
+
+登録されたツール名を一行ずつソートして出力。
+
+```bash
+$ twikit-mcp list
+add_list_member
+block_user
+…
+vote
+```
+
+#### `call <tool> [key=value …]`
+
+ツールを 1 回呼び出し、JSON 出力をプリント。
+
+```bash
+$ twikit-mcp call get_user_info screen_name=elonmusk
+{"id":"44196397","screen_name":"elonmusk", …}
+
+$ twikit-mcp call search_tweets query=AI count=5 product=Top
+[…]
+
+$ twikit-mcp call get_tweet tweet_id=20 | jq .text
+"just setting up my twttr"
+```
+
+### 型変換
+
+CLI 引数は文字列で渡されるので、ツールのアノテーションに合わせて変換:
+
+| アノテーション | 変換 |
+|---|---|
+| `str` | そのまま |
+| `int` / `float` | `int(value)` / `float(value)` |
+| `bool` | 緩い一致:`true / 1 / yes / on`(大文字小文字不問)→ `True`;それ以外 → `False` |
+| `Optional[X]` / `X \| None` | `X` にアンラップ;**空文字列 → `None`** を明示的にエスケープ |
+| その他 | 文字列のままパススルー |
+
+KV 分割は**最初の `=` のみ** — URL / base64 / JWT に含まれる追加の `=` は保持されます。
+
+### 終了コード
+
+| Code | 意味 |
+|---|---|
+| `0` | 成功 |
+| `1` | argparse / 使用法エラー |
+| `2` | `ToolError`(引数バリデーション失敗 or twikit が型付き例外を投げた) |
+| その他 | キャッチされなかった例外 — バグなので issue を立ててください |
+
+### Tips
+
+```bash
+# jq にパイプ
+twikit-mcp call get_user_info screen_name=elonmusk | jq .followers_count
+
+# cron で定期スナップショット
+0 10 * * 1   /usr/local/bin/twikit-mcp call get_trends category=trending count=20 \
+             > "$HOME/trends/$(date +%F).json"
+
+# 未知の引数エラーで有効な args を発見
+$ twikit-mcp call get_user_info bogus=x
+Unknown arg `bogus` for tool `get_user_info`. Valid args: ['screen_name', 'user_id']
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,42 +1,135 @@
 # twikit-mcp
 
-**Twitter/X MCP server — no API key needed.**
+**Twitter/X MCP server + CLI — no API key needed.**
 
 [![PyPI](https://img.shields.io/pypi/v/twikit-mcp)](https://pypi.org/project/twikit-mcp/)
 [![CI](https://github.com/tangivis/twitter-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/tangivis/twitter-mcp/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/tangivis/twitter-mcp/blob/main/LICENSE)
 
-An [MCP](https://modelcontextprotocol.io/) server that lets Claude (or any MCP-compatible AI agent) interact with Twitter/X using browser cookies. No Twitter API key, no developer-account approval, no monthly bill.
+**[English](#english)** | **[中文](#zh)** | **[日本語](#ja)**
 
-## What you get
+---
+
+## English
+
+An [MCP](https://modelcontextprotocol.io/) server that lets Claude (or any MCP-compatible AI agent) interact with Twitter/X using browser cookies. The same `twikit-mcp` binary doubles as a CLI for shell scripts and debugging.
+
+### What you get
 
 - **57 tools** covering tweets, users, lists, communities, scheduled tweets + polls, DMs, articles, search, trends, notifications.
-- **Browser-cookie auth** — copy `ct0` + `auth_token` from your X session, and you're authenticated.
-- **Single binary** — `pip install twikit-mcp` or `uvx twikit-mcp`. No background services.
-- **Vendored [twikit](https://github.com/d60/twikit)** with project-specific defensive patches (see [Vendoring](VENDORING.md)).
+- **Browser-cookie auth** — copy `ct0` + `auth_token` from your X session, you're authenticated.
+- **Two transports, one binary** — MCP server (default) for AI agents; `twikit-mcp call <tool>` CLI for shells.
+- **Vendored [twikit](https://github.com/d60/twikit)** with project-specific defensive patches.
 
-## Where to go next
+### Where to go
 
-- **[MCP Tools API](api.md)** — auto-generated reference of all 57 tools, with **MCP and CLI usage** side by side for each tool. Read this when you want to know what a specific tool does.
-- **[CLI mode](cli.md)** — the same `twikit-mcp` binary as a one-shot CLI. Subcommands, type coercion, exit codes, examples.
-- **[Technical design](TECHNICAL.md)** — how the server works internally, how tool output shapes are kept compact, etc.
-- **[Vendoring twikit](VENDORING.md)** — every patch applied to the vendored copy, with the issue that motivated it.
-- **[Repo on GitHub](https://github.com/tangivis/twitter-mcp)** — README has install / quickstart in English / 中文 / 日本語.
+- **[CLI mode](cli.md)** — subcommands, type coercion, exit codes, examples.
+- **[MCP Tools API](api.md)** — auto-generated reference: every tool's signature + docstring + CLI example, kept in sync with code.
+- **[Technical design](TECHNICAL.md)** — internals.
+- **[Vendoring twikit](VENDORING.md)** — every patch and the issue that motivated it.
+- **[GitHub repo](https://github.com/tangivis/twitter-mcp)** — README has full install / quickstart in three languages.
 
-## Quick install
+### Quick install
 
 ```bash
-# Copy ct0 + auth_token from x.com cookies, then:
+# 1. Drop your X cookies into ~/.config/twitter-mcp/cookies.json
 mkdir -p ~/.config/twitter-mcp
 cat > ~/.config/twitter-mcp/cookies.json <<'EOF'
 {"ct0": "...", "auth_token": "..."}
 EOF
 chmod 600 ~/.config/twitter-mcp/cookies.json
 
-# Install + register with Claude Code:
+# 2. Install (recommended for daily use)
+uv tool install twikit-mcp
+
+# 3. Register with Claude Code
 claude mcp add twitter -s user \
   -e "TWITTER_COOKIES=$HOME/.config/twitter-mcp/cookies.json" \
-  -- uvx twikit-mcp
+  -- twikit-mcp
 ```
 
-Full instructions including 中文 / 日本語 versions are on [the GitHub README](https://github.com/tangivis/twitter-mcp#readme).
+Use `uv tool upgrade twikit-mcp` to update; full alternatives (uvx / pip / pipx) on the [GitHub README](https://github.com/tangivis/twitter-mcp#readme).
+
+---
+
+## 中文 { #zh }
+
+[MCP](https://modelcontextprotocol.io/) server,让 Claude(或任何 MCP 兼容的 AI agent)用浏览器 cookies 操作 Twitter/X。同一个 `twikit-mcp` 二进制还能当 CLI 用,适合 shell 脚本和调试。
+
+### 你能拿到什么
+
+- **57 个工具** — 推文、用户、列表、社群、定时推文+投票、私信、文章、搜索、趋势、通知。
+- **浏览器 cookie 认证** — 从你的 X 会话拷 `ct0` + `auth_token`,搞定。
+- **两种传输,一个二进制** — 默认是 MCP server(给 AI agent 用),`twikit-mcp call <tool>` 是 CLI(给 shell 用)。
+- **vendored 版 [twikit](https://github.com/d60/twikit)** — 带项目自己打的防御补丁。
+
+### 文档导航
+
+- **[CLI 模式](cli.md)** — 子命令、类型转换、退出码、例子。
+- **[MCP 工具 API](api.md)** — 自动生成的参考:每个工具的签名 + docstring + CLI 调用例子,跟代码同步。
+- **[技术设计](TECHNICAL.md)** — 内部实现。
+- **[Vendoring twikit](VENDORING.md)** — 每个补丁和对应的 issue。
+- **[GitHub repo](https://github.com/tangivis/twitter-mcp)** — README 有三语完整安装 / 快速开始。
+
+### 快速安装
+
+```bash
+# 1. 把 X cookies 放进 ~/.config/twitter-mcp/cookies.json
+mkdir -p ~/.config/twitter-mcp
+cat > ~/.config/twitter-mcp/cookies.json <<'EOF'
+{"ct0": "...", "auth_token": "..."}
+EOF
+chmod 600 ~/.config/twitter-mcp/cookies.json
+
+# 2. 安装(日常使用推荐)
+uv tool install twikit-mcp
+
+# 3. 注册到 Claude Code
+claude mcp add twitter -s user \
+  -e "TWITTER_COOKIES=$HOME/.config/twitter-mcp/cookies.json" \
+  -- twikit-mcp
+```
+
+升级用 `uv tool upgrade twikit-mcp`;其他方式(uvx / pip / pipx)见 [GitHub README](https://github.com/tangivis/twitter-mcp#readme)。
+
+---
+
+## 日本語 { #ja }
+
+[MCP](https://modelcontextprotocol.io/) サーバー — Claude(や MCP 対応の AI エージェント)がブラウザ cookies で Twitter/X を操作できます。同じ `twikit-mcp` バイナリは CLI としてもシェルスクリプトやデバッグに使えます。
+
+### 得られるもの
+
+- **57 ツール** — ツイート、ユーザー、リスト、コミュニティ、予約投稿+投票、DM、記事、検索、トレンド、通知。
+- **ブラウザ cookie 認証** — X セッションから `ct0` と `auth_token` をコピーするだけ。
+- **2 つのトランスポート、1 つのバイナリ** — デフォルトは MCP サーバー(AI エージェント向け)、`twikit-mcp call <tool>` は CLI(シェル向け)。
+- **vendored 版 [twikit](https://github.com/d60/twikit)** — プロジェクト固有の防御パッチ付き。
+
+### ドキュメント
+
+- **[CLI モード](cli.md)** — サブコマンド、型変換、終了コード、例。
+- **[MCP ツール API](api.md)** — 自動生成のリファレンス:各ツールのシグネチャ、docstring、CLI 例(コードと同期)。
+- **[技術設計](TECHNICAL.md)** — 内部実装。
+- **[twikit のベンダリング](VENDORING.md)** — すべてのパッチと対応する issue。
+- **[GitHub リポジトリ](https://github.com/tangivis/twitter-mcp)** — README に三言語のフルインストール手順。
+
+### クイックインストール
+
+```bash
+# 1. X cookies を ~/.config/twitter-mcp/cookies.json に保存
+mkdir -p ~/.config/twitter-mcp
+cat > ~/.config/twitter-mcp/cookies.json <<'EOF'
+{"ct0": "...", "auth_token": "..."}
+EOF
+chmod 600 ~/.config/twitter-mcp/cookies.json
+
+# 2. インストール(日常利用に推奨)
+uv tool install twikit-mcp
+
+# 3. Claude Code に登録
+claude mcp add twitter -s user \
+  -e "TWITTER_COOKIES=$HOME/.config/twitter-mcp/cookies.json" \
+  -- twikit-mcp
+```
+
+アップグレードは `uv tool upgrade twikit-mcp`;その他のオプション(uvx / pip / pipx)は [GitHub README](https://github.com/tangivis/twitter-mcp#readme) を参照。


### PR DESCRIPTION
## Why three things in one PR

All three are tied to the same goal — **end-to-end autonomy that actually reaches PyPI + docs site**, including documenting the install path users will actually use.

## 1. PAT-backed auto-merge (the missing piece)

**Symptom:** PR #49 merged via auto-merge but `publish.yml` never fired → 0.1.22 stuck.

**Cause:** GitHub anti-loop protection — pushes by `GITHUB_TOKEN` don't trigger downstream workflows. Our `gh pr merge` ran under `GITHUB_TOKEN`, so the resulting `push: main` was invisible to publish.yml + docs.yml.

**Fix:**
```yaml
GH_TOKEN: ${{ secrets.MERGE_PAT || secrets.GITHUB_TOKEN }}
```

If `MERGE_PAT` is set (fine-grained PAT, `contents + pull_requests: write`), cascade works — release reaches PyPI without human touch. If unset, falls back to `GITHUB_TOKEN`; merge still happens, just no downstream cascade (warning logged so the degradation isn't silent).

Every other workflow step (review, comments, labels, summons) stays on `GITHUB_TOKEN` — they don't push code so anti-loop doesn't apply.

## 2. `uv tool install` docs (English / 中文 / 日本語)

Added as **Option B** (between A=uvx and C=pip). Covers:
- `uv tool install / list / upgrade / upgrade --all / uninstall` lifecycle
- Note that cookies path is **unchanged** — only binary location moves
- Side-by-side rule: uvx for one-off, `uv tool install` for daily Claude Code use

Three languages, idiomatic in each.

## 3. Docs site landing + CLI page now tri-lingual

`docs/index.md` and `docs/cli.md` now open with:
```
**[English](#english)** | **[中文](#zh)** | **[日本語](#ja)**
```

Three sections each, with explicit `{ #zh }` / `{ #ja }` HTML ids via `attr_list` (already enabled). Default mkdocs slugify drops non-ASCII; explicit ids fix that without an i18n plugin restructure.

`api.md` (auto-generated from docstrings — types are English) and `TECHNICAL.md` / `VENDORING.md` (internals, already mostly 中文) stay as-is.

## Test plan

- [x] 521 tests pass; `twitter_mcp/server.py` 100% coverage; `--cov-fail-under=95`
- [x] Local `mkdocs build` clean (only pre-existing TECHNICAL.md cross-link warnings — out of scope)
- [x] ruff format + check pass
- [ ] CI green on PR
- [ ] MiniMax decision = comment / approve → auto-merge fires
- [ ] **If MERGE_PAT is set when this PR merges:** publish.yml + docs.yml auto-trigger and finish on their own
- [ ] **If not set:** the warning fires + maintainer triggers publish.yml manually

## Manual maintainer step (one-time, unlocks full autonomy)

1. **Generate fine-grained PAT**: Settings → Developer settings → Personal access tokens → Fine-grained
   - Repository access: only `tangivis/twitter-mcp`
   - Permissions: `Contents: Read and write`, `Pull requests: Read and write`
   - Expiration: 90 days or 1 year
2. **Add as secret**: Repo Settings → Secrets and variables → Actions → New repository secret named `MERGE_PAT`, value = the PAT.

Skip step 1 if you're OK manually triggering publish.yml on each release.

## Spec / SDD checklist

- [x] No new MCP tool
- [x] No test fixture changes
- [x] No vendor patches
- [x] No live-smoke validators
- [x] Tool count unchanged (still 57)

https://claude.ai/code/session_01YZ5NXtFwvf3yybuRVSzvPY

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZ5NXtFwvf3yybuRVSzvPY)_