### PR TITLE
feat: human-friendly CLI subcommands + UTF-8 JSON output (closes #52)

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,26 +151,38 @@ That's it. Start talking:
 
 #### CLI mode (no MCP client needed)
 
-The same `twikit-mcp` binary doubles as a one-shot CLI for shell scripts and quick debugging — `serve` is the default behavior, `list` / `call` are subcommands:
+The same `twikit-mcp` binary doubles as a one-shot CLI. Two modes:
+
+**Human-friendly subcommands** — pretty-print tweets, profiles, timeline directly:
 
 ```bash
-# List all available tools
-twikit-mcp list
-
-# Invoke a tool (key=value args; types coerced from your tool signature)
-twikit-mcp call get_user_info screen_name=elonmusk
-twikit-mcp call search_tweets query=AI count=5 product=Top
-twikit-mcp call get_tweet tweet_id=20
-
-# Pipe to jq
-twikit-mcp call get_user_info screen_name=elonmusk | jq .followers_count
-
-# Default mode (no subcommand) is still the MCP server over stdio —
-# every existing client config keeps working unchanged.
-twikit-mcp
+twikit-mcp tweet 20                     # show tweet 20 (Jack's first one)
+twikit-mcp tweet https://x.com/u/status/123    # URL works too
+twikit-mcp user elonmusk                # pretty profile
+twikit-mcp tl 10                        # last 10 tweets from your home timeline
+twikit-mcp search "AI" 5                # 5 top results for "AI"
+twikit-mcp trends 20                    # top 20 trending topics
 ```
 
-Use the same `~/.config/twitter-mcp/cookies.json` file — no separate config.
+Output is plain text — readable in any terminal, native unicode (no `\uXXXX` escapes).
+
+**Machine-friendly subcommands** — raw JSON, `key=value` args, every one of the 57 MCP tools:
+
+```bash
+twikit-mcp list                         # all 57 tool names
+twikit-mcp call get_user_info screen_name=elonmusk
+twikit-mcp call search_tweets query=AI count=5 product=Top
+twikit-mcp call get_user_info screen_name=elonmusk | jq .followers_count
+```
+
+**MCP server mode** — the default when no subcommand is given:
+
+```bash
+twikit-mcp                              # stdio JSON-RPC for MCP clients
+twikit-mcp serve                        # explicit, same behavior
+```
+
+All three modes share the same `~/.config/twitter-mcp/cookies.json` — no separate config.
 
 ### Available Tools
 

--- a/docs/cli.en.md
+++ b/docs/cli.en.md
@@ -1,15 +1,40 @@
 # CLI mode
 
-`twikit-mcp` is a dual-mode binary: same install, two transports.
+`twikit-mcp` is a multi-mode binary. Same install, three flavors:
 
 | Mode | Command | When |
 |---|---|---|
 | **MCP server** (default) | `twikit-mcp` or `twikit-mcp serve` | Inside an AI agent (Claude Code, Cursor, Cline, …). LLM sends JSON-RPC over stdio. |
-| **CLI** | `twikit-mcp list` / `twikit-mcp call <tool> …` | Shell scripts, automation, debugging. |
+| **Human-friendly CLI** | `twikit-mcp tweet 20`, `twikit-mcp user elonmusk`, etc. | You're at a shell, you want to read a tweet / profile / timeline. Output is plain text, native unicode. |
+| **Machine CLI** | `twikit-mcp list` / `twikit-mcp call <tool> key=value …` | Shell scripts, automation, debugging. Raw JSON output, every one of the 57 tools available. |
 
-Both share the same cookies file (`~/.config/twitter-mcp/cookies.json`) and the same 57 tools.
+All three share the same cookies file (`~/.config/twitter-mcp/cookies.json`).
 
-## Subcommands
+## Human-friendly subcommands
+
+Pretty-printed text output, positional args, no JSON. Five subcommands cover the common "I want to read X" cases:
+
+```bash
+twikit-mcp tweet 20                       # one tweet pretty-printed
+twikit-mcp tweet https://x.com/jack/status/20  # URL works too
+twikit-mcp user elonmusk                  # one profile
+twikit-mcp tl 10                          # last 10 from your home timeline
+twikit-mcp search "AI" 5                  # 5 top search results
+twikit-mcp trends 20                      # top 20 trending topics
+```
+
+Sample output:
+
+```
+@pathfinderSport · Pathfinder Sports
+Άρσεναλ - Σάντερλαντ: (X) 0-0 τελικό
+❤ 7,269  🔁 5,473  · Sat Feb 21 16:55:22 +0000 2009
+https://x.com/pathfinderSport/status/1234567890
+```
+
+These are wrappers over the same MCP tools; if you need different args (`product=Latest`, custom `cursor`, etc.), drop down to `call`.
+
+## Machine subcommands
 
 ### `serve` (default)
 

--- a/docs/cli.ja.md
+++ b/docs/cli.ja.md
@@ -1,15 +1,40 @@
 # CLI モード
 
-`twikit-mcp` はデュアルモードのバイナリです — 同じインストールで、2 つの利用方法。
+`twikit-mcp` はマルチモードのバイナリです。同じインストールで、3 種類の使い方:
 
 | モード | コマンド | 使う場面 |
 |---|---|---|
-| **MCP サーバー**(デフォルト) | `twikit-mcp` または `twikit-mcp serve` | AI エージェント(Claude Code、Cursor、Cline など)から呼び出し、LLM が stdio 経由で JSON-RPC を送る |
-| **CLI** | `twikit-mcp list` / `twikit-mcp call <tool> …` | シェルスクリプト、自動化、デバッグ |
+| **MCP サーバー**(デフォルト) | `twikit-mcp` または `twikit-mcp serve` | AI エージェント(Claude Code、Cursor、Cline など)、LLM が stdio 経由で JSON-RPC を送る |
+| **ヒューマン CLI** | `twikit-mcp tweet 20`、`twikit-mcp user elonmusk` など | シェルでツイート / プロフィール / タイムラインを直接読みたいとき。出力はプレーンテキスト、ネイティブ Unicode |
+| **マシン CLI** | `twikit-mcp list` / `twikit-mcp call <tool> key=value …` | シェルスクリプト、自動化、デバッグ。生 JSON 出力、57 ツール全部呼べる |
 
-両モードとも**同じ cookies ファイル**(`~/.config/twitter-mcp/cookies.json`)と同じ 57 ツールを共有します。
+3 モードとも**同じ cookies ファイル**(`~/.config/twitter-mcp/cookies.json`)を共有します。
 
-## サブコマンド
+## ヒューマン用サブコマンド
+
+整形済みテキスト、位置引数、JSON なし。「X を読みたい」の典型ケースを 5 つカバー:
+
+```bash
+twikit-mcp tweet 20                       # 1 ツイートを整形表示
+twikit-mcp tweet https://x.com/jack/status/20  # URL も可
+twikit-mcp user elonmusk                  # 1 プロフィール
+twikit-mcp tl 10                          # 自分のホームタイムライン直近 10 件
+twikit-mcp search "AI" 5                  # "AI" のトップ 5 検索結果
+twikit-mcp trends 20                      # トップ 20 トレンド
+```
+
+出力例:
+
+```
+@pathfinderSport · Pathfinder Sports
+Άρσεναλ - Σάντερλαντ: (X) 0-0 τελικό
+❤ 7,269  🔁 5,473  · Sat Feb 21 16:55:22 +0000 2009
+https://x.com/pathfinderSport/status/1234567890
+```
+
+これらは同じ MCP ツール群の薄いラッパーです。より細かな引数(`product=Latest` / カスタム `cursor` など)が必要なら `call` を使ってください。
+
+## マシン用サブコマンド
 
 ### `serve`(デフォルト)
 

--- a/docs/cli.zh.md
+++ b/docs/cli.zh.md
@@ -1,15 +1,40 @@
 # CLI 模式
 
-`twikit-mcp` 是双模式二进制 — 同一个安装,两种调用方式。
+`twikit-mcp` 是多模式二进制。同一个安装,三种用法:
 
 | 模式 | 命令 | 何时用 |
 |---|---|---|
-| **MCP server**(默认) | `twikit-mcp` 或 `twikit-mcp serve` | AI agent 里调用(Claude Code、Cursor、Cline 等),LLM 通过 stdio 发 JSON-RPC |
-| **CLI** | `twikit-mcp list` / `twikit-mcp call <tool> …` | shell 脚本、自动化、调试 |
+| **MCP server**(默认) | `twikit-mcp` 或 `twikit-mcp serve` | AI agent 里(Claude Code、Cursor、Cline 等),LLM 通过 stdio 发 JSON-RPC |
+| **人用 CLI** | `twikit-mcp tweet 20`、`twikit-mcp user elonmusk` 等 | 在 shell 里想读条推 / 看个 profile / 刷下 timeline。输出是纯文本,原生中日韩文(无转义) |
+| **机器 CLI** | `twikit-mcp list` / `twikit-mcp call <tool> key=value …` | shell 脚本、自动化、调试。raw JSON 输出,57 个工具全都能调 |
 
-两种模式**共享同一个** cookies 文件(`~/.config/twitter-mcp/cookies.json`)和同样的 57 个工具。
+三种模式**共享同一个** cookies 文件(`~/.config/twitter-mcp/cookies.json`)。
 
-## 子命令
+## 人用子命令
+
+文本输出、位置参数、不输出 JSON。五个子命令覆盖"我就想读 X"的常见场景:
+
+```bash
+twikit-mcp tweet 20                       # 一条推漂亮打印
+twikit-mcp tweet https://x.com/jack/status/20  # URL 也能用
+twikit-mcp user elonmusk                  # 一个用户的 profile
+twikit-mcp tl 10                          # 自己 home timeline 最近 10 条
+twikit-mcp search "AI" 5                  # "AI" 的 top 5 搜索结果
+twikit-mcp trends 20                      # top 20 热门话题
+```
+
+样例输出:
+
+```
+@pathfinderSport · Pathfinder Sports
+Άρσεναλ - Σάντερλαντ: (X) 0-0 τελικό
+❤ 7,269  🔁 5,473  · Sat Feb 21 16:55:22 +0000 2009
+https://x.com/pathfinderSport/status/1234567890
+```
+
+这些只是同一组 MCP 工具的轻包装。需要更细的参数(`product=Latest` / 自定义 `cursor` 等)直接走 `call`。
+
+## 机器子命令
 
 ### `serve`(默认)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -228,5 +228,273 @@ def test_subprocess_help_mentions_subcommands():
     r = _run_cli("--help")
     assert r.returncode == 0
     out = r.stdout
-    for sub in ("serve", "list", "call"):
+    # Both machine-shaped and human-shaped subcommands are advertised.
+    for sub in ("serve", "list", "call", "tweet", "user", "tl", "search", "trends"):
         assert sub in out
+
+
+# ── Human-friendly formatters ────────────────────────
+
+
+def test_compact_num_passes_small_unchanged():
+    from twitter_mcp.server import _compact_num
+
+    assert _compact_num(0) == "0"
+    assert _compact_num(42) == "42"
+    assert _compact_num(9999) == "9,999"
+
+
+def test_compact_num_thousands_to_K():
+    from twitter_mcp.server import _compact_num
+
+    assert _compact_num(12_500) == "12.5K"
+    assert _compact_num(999_500) == "999.5K"
+
+
+def test_compact_num_millions_billions():
+    from twitter_mcp.server import _compact_num
+
+    assert _compact_num(1_500_000) == "1.5M"
+    assert _compact_num(2_300_000_000) == "2.3B"
+
+
+def test_compact_num_handles_non_numeric():
+    """Defensive: tools sometimes pass through whatever twikit returns."""
+    from twitter_mcp.server import _compact_num
+
+    assert _compact_num(None) == "None"
+    assert _compact_num("not a number") == "not a number"
+
+
+def test_format_tweet_renders_unicode_natively():
+    """JSON-escape bug regression: real text content (Greek, 中文, …) must
+    show as native characters in the human-format output."""
+    from twitter_mcp.server import _format_tweet
+
+    block = _format_tweet(
+        {
+            "id": "1234567890",
+            "author": "pathfinderSport",
+            "author_name": "Pathfinder Sports",
+            "text": "Άρσεναλ - Σάντερλαντ: (X) 0-0 τελικό",
+            "created_at": "Sat Feb 21 16:55:22 +0000 2009",
+            "likes": 7269,
+            "retweets": 5473,
+        }
+    )
+    # All the pieces show up as readable text — no \uXXXX escapes anywhere.
+    assert "@pathfinderSport · Pathfinder Sports" in block
+    assert "Άρσεναλ - Σάντερλαντ" in block
+    assert "❤ 7,269" in block
+    assert "🔁 5,473" in block
+    assert "https://x.com/pathfinderSport/status/1234567890" in block
+
+
+def test_format_tweet_tolerates_missing_fields():
+    """Tools sometimes omit author_name / created_at / counts on edge cases."""
+    from twitter_mcp.server import _format_tweet
+
+    block = _format_tweet({"id": "1", "author": "alice", "text": "hi"})
+    assert "@alice" in block
+    assert "hi" in block
+
+
+def test_format_tweet_list_numbers_entries():
+    from twitter_mcp.server import _format_tweet_list
+
+    out = _format_tweet_list(
+        [
+            {"id": "1", "author": "a", "text": "first"},
+            {"id": "2", "author": "b", "text": "second"},
+        ]
+    )
+    assert "[1]" in out and "[2]" in out
+    assert "first" in out and "second" in out
+
+
+def test_format_tweet_list_handles_empty():
+    from twitter_mcp.server import _format_tweet_list
+
+    assert _format_tweet_list([]) == "(no tweets)"
+
+
+def test_format_user_renders_compact_followers():
+    from twitter_mcp.server import _format_user
+
+    block = _format_user(
+        {
+            "screen_name": "elonmusk",
+            "name": "Elon Musk",
+            "is_blue_verified": True,
+            "description": "CEO",
+            "followers_count": 200_453_876,
+            "following_count": 1_123,
+            "tweets_count": 50_432,
+            "location": "Texas, USA",
+            "url": "https://example.com",
+            "created_at": "Tue Jun 02 …",
+        }
+    )
+    assert "@elonmusk" in block
+    assert "Elon Musk" in block
+    assert "✓" in block  # verified glyph
+    assert "Followers: 200.5M" in block
+    assert "Texas, USA" in block
+    assert "https://x.com/elonmusk" in block
+
+
+def test_format_trends_numbered():
+    from twitter_mcp.server import _format_trends
+
+    out = _format_trends(
+        {
+            "trends": [
+                {"name": "AI", "tweets_count": 50000, "domain_context": "Tech"},
+                {"name": "コーヒー", "tweets_count": 1234},
+            ]
+        }
+    )
+    # Native unicode preserved.
+    assert "コーヒー" in out
+    assert " 1." in out and " 2." in out
+    assert "50.0K tweets" in out
+    assert "Tech" in out
+
+
+def test_format_trends_empty():
+    from twitter_mcp.server import _format_trends
+
+    assert _format_trends({"trends": []}) == "(no trends)"
+    assert _format_trends({}) == "(no trends)"
+
+
+# ── Human-CLI subcommands (subprocess integration) ────
+
+
+def test_subprocess_tweet_unknown_id_clean_error():
+    """`tweet` with bogus id → exit 2 (ToolError translated cleanly)."""
+    r = _run_cli("tweet", "definitely_not_a_tweet_id_123")
+    assert r.returncode != 0
+
+
+def test_subprocess_user_unknown_clean_error():
+    r = _run_cli("user", "screen_name_that_does_not_exist_xyz_42")
+    assert r.returncode != 0
+
+
+# ── Human-CLI dispatcher (unit-mocked) ───────────────
+
+
+async def _mock_call_tool(monkeypatch, mapping: dict[str, str]):
+    """Patch `_call_tool_async` to return fixed JSON strings keyed by tool name."""
+    from unittest.mock import AsyncMock
+
+    async def fake(tool_name, kwargs):
+        return mapping[tool_name]
+
+    monkeypatch.setattr(server, "_call_tool_async", AsyncMock(side_effect=fake))
+
+
+async def test_human_tweet_calls_get_tweet_and_formats(monkeypatch):
+    await _mock_call_tool(
+        monkeypatch,
+        {
+            "get_tweet": json.dumps(
+                {"id": "20", "author": "jack", "text": "hi", "likes": 1, "retweets": 0}
+            )
+        },
+    )
+    out = await server._human_tweet("20")
+    assert "@jack" in out
+    assert "hi" in out
+
+
+async def test_human_user_calls_get_user_info(monkeypatch):
+    await _mock_call_tool(
+        monkeypatch,
+        {
+            "get_user_info": json.dumps(
+                {
+                    "screen_name": "alice",
+                    "name": "Alice",
+                    "followers_count": 0,
+                    "following_count": 0,
+                    "tweets_count": 0,
+                }
+            )
+        },
+    )
+    out = await server._human_user("alice")
+    assert "@alice" in out
+
+
+async def test_human_timeline_renders_list(monkeypatch):
+    await _mock_call_tool(
+        monkeypatch,
+        {
+            "get_timeline": json.dumps(
+                [
+                    {"id": "1", "author": "a", "text": "first"},
+                    {"id": "2", "author": "b", "text": "second"},
+                ]
+            )
+        },
+    )
+    out = await server._human_timeline(20)
+    assert "[1]" in out and "[2]" in out
+
+
+async def test_human_search_uses_top_product(monkeypatch):
+    """search subcommand pins product='Top' — verify it's passed through."""
+    captured = {}
+
+    async def fake_call(tool_name, kwargs):
+        captured["tool"] = tool_name
+        captured["kwargs"] = kwargs
+        return json.dumps([])
+
+    from unittest.mock import AsyncMock
+
+    monkeypatch.setattr(server, "_call_tool_async", AsyncMock(side_effect=fake_call))
+    await server._human_search("AI", 5)
+    assert captured["tool"] == "search_tweets"
+    assert captured["kwargs"] == {"query": "AI", "count": "5", "product": "Top"}
+
+
+async def test_human_trends_renders(monkeypatch):
+    await _mock_call_tool(
+        monkeypatch,
+        {"get_trends": json.dumps({"trends": [{"name": "AI", "tweets_count": 10000}]})},
+    )
+    out = await server._human_trends(20)
+    assert "AI" in out
+    assert "10.0K" in out
+
+
+# ── ensure_ascii regression for tool outputs ─────────
+
+
+async def test_tool_output_preserves_unicode_raw(monkeypatch):
+    """Greek-tweet regression: get_tweet's JSON output must contain native
+    non-ASCII chars, not `\\uXXXX` escapes. This is the bug a user hit
+    when piping CLI output back through their terminal."""
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock
+
+    fake_tweet = SimpleNamespace(
+        id="1234567890",
+        text="Άρσεναλ - Σάντερλαντ: (X) 0-0 τελικό",
+        user=SimpleNamespace(screen_name="pathfinderSport", name="Pathfinder Sports"),
+        favorite_count=7269,
+        retweet_count=5473,
+        created_at="Sat Feb 21 16:55:22 +0000 2009",
+    )
+    fake_client = AsyncMock()
+    fake_client.get_tweets_by_ids = AsyncMock(return_value=[fake_tweet])
+    monkeypatch.setattr(server, "_get_client", AsyncMock(return_value=fake_client))
+
+    out = await server.get_tweet("1234567890")
+    # Negative: NOT escaped.
+    assert "\\u" not in out
+    # Positive: native characters present in the raw string.
+    assert "Άρσεναλ" in out

--- a/twitter_mcp/server.py
+++ b/twitter_mcp/server.py
@@ -63,6 +63,22 @@ async def _get_client() -> Client:
     return client
 
 
+def _dumps(obj) -> str:
+    """JSON-encode a tool output with native non-ASCII characters preserved.
+
+    `json.dumps` defaults to `ensure_ascii=True`, which turns 中文 / 日本語 /
+    希腊文 / emoji / etc. into `\\uXXXX` escapes. That makes tool outputs
+    technically valid JSON but unreadable when an LLM reads them or a human
+    pipes them through the CLI. Always emit raw UTF-8 instead.
+    """
+    # NOTE: must call stdlib `json.dumps` directly here. The project-wide
+    # rewrite that introduced this helper renamed every `json.dumps(` to
+    # `_dumps(`, including this line — left unfixed it infinite-recurses.
+    import json as _stdlib_json
+
+    return _stdlib_json.dumps(obj, ensure_ascii=False)
+
+
 def _parse_article_url_or_id(value: str | None) -> str | None:
     """Return the article rest_id if `value` is an /i/article/<id> URL, else None.
 
@@ -95,7 +111,7 @@ async def send_tweet(text: str, reply_to: str | None = None) -> str:
     """
     client = await _get_client()
     tweet = await client.create_tweet(text=text, reply_to=reply_to)
-    return json.dumps({"id": tweet.id, "text": text, "status": "sent"})
+    return _dumps({"id": tweet.id, "text": text, "status": "sent"})
 
 
 @mcp.tool()
@@ -122,7 +138,7 @@ async def get_tweet(tweet_id: str) -> str:
             f"use get_article instead."
         )
     t = tweets[0]
-    return json.dumps(
+    return _dumps(
         {
             "id": t.id,
             "author": t.user.screen_name,
@@ -155,7 +171,7 @@ async def get_timeline(count: int = 20) -> str:
                 "retweets": t.retweet_count,
             }
         )
-    return json.dumps(result)
+    return _dumps(result)
 
 
 @mcp.tool()
@@ -180,7 +196,7 @@ async def search_tweets(query: str, count: int = 20, product: str = "Latest") ->
                 "retweets": t.retweet_count,
             }
         )
-    return json.dumps(result)
+    return _dumps(result)
 
 
 @mcp.tool()
@@ -192,7 +208,7 @@ async def like_tweet(tweet_id: str) -> str:
     """
     client = await _get_client()
     await client.favorite_tweet(tweet_id)
-    return json.dumps({"tweet_id": tweet_id, "status": "liked"})
+    return _dumps({"tweet_id": tweet_id, "status": "liked"})
 
 
 @mcp.tool()
@@ -204,7 +220,7 @@ async def retweet(tweet_id: str) -> str:
     """
     client = await _get_client()
     await client.retweet(tweet_id)
-    return json.dumps({"tweet_id": tweet_id, "status": "retweeted"})
+    return _dumps({"tweet_id": tweet_id, "status": "retweeted"})
 
 
 @mcp.tool()
@@ -229,7 +245,7 @@ async def get_user_tweets(screen_name: str, count: int = 20) -> str:
                 "retweets": t.retweet_count,
             }
         )
-    return json.dumps(result)
+    return _dumps(result)
 
 
 _PAGINATED_MAX_COUNT = 100
@@ -301,7 +317,7 @@ async def get_user_info(
             f"User not found: {screen_name or user_id}. Check the spelling / id."
         )
 
-    return json.dumps(
+    return _dumps(
         {
             "id": u.id,
             "screen_name": u.screen_name,
@@ -373,7 +389,7 @@ async def get_user_followers(
         raise ToolError(f"User not found: {screen_name or user_id}.")
 
     users = [_user_to_dict(u) for u in result]
-    return json.dumps(
+    return _dumps(
         {
             "users": users,
             "next_cursor": getattr(result, "next_cursor", None),
@@ -420,7 +436,7 @@ async def get_user_following(
         raise ToolError(f"User not found: {screen_name or user_id}.")
 
     users = [_user_to_dict(u) for u in result]
-    return json.dumps(
+    return _dumps(
         {
             "users": users,
             "next_cursor": getattr(result, "next_cursor", None),
@@ -442,7 +458,7 @@ async def follow_user(screen_name: str) -> str:
     client = await _get_client()
     user = await client.get_user_by_screen_name(screen_name)
     await client.follow_user(user.id)
-    return json.dumps(
+    return _dumps(
         {"user_id": user.id, "screen_name": screen_name, "status": "followed"}
     )
 
@@ -460,7 +476,7 @@ async def unfollow_user(screen_name: str) -> str:
     client = await _get_client()
     user = await client.get_user_by_screen_name(screen_name)
     await client.unfollow_user(user.id)
-    return json.dumps(
+    return _dumps(
         {"user_id": user.id, "screen_name": screen_name, "status": "unfollowed"}
     )
 
@@ -479,7 +495,7 @@ async def delete_tweet(tweet_id: str) -> str:
         raise ToolError(f"X rate limit exceeded; retry later. ({e})")
     except NotFound:
         raise ToolError(f"Tweet {tweet_id} not found.")
-    return json.dumps({"tweet_id": tweet_id, "status": "deleted"})
+    return _dumps({"tweet_id": tweet_id, "status": "deleted"})
 
 
 @mcp.tool()
@@ -496,7 +512,7 @@ async def unfavorite_tweet(tweet_id: str) -> str:
         raise ToolError(f"X rate limit exceeded; retry later. ({e})")
     except NotFound:
         raise ToolError(f"Tweet {tweet_id} not found.")
-    return json.dumps({"tweet_id": tweet_id, "status": "unliked"})
+    return _dumps({"tweet_id": tweet_id, "status": "unliked"})
 
 
 @mcp.tool()
@@ -513,7 +529,7 @@ async def delete_retweet(tweet_id: str) -> str:
         raise ToolError(f"X rate limit exceeded; retry later. ({e})")
     except NotFound:
         raise ToolError(f"Tweet {tweet_id} not found.")
-    return json.dumps({"tweet_id": tweet_id, "status": "un-retweeted"})
+    return _dumps({"tweet_id": tweet_id, "status": "un-retweeted"})
 
 
 @mcp.tool()
@@ -534,7 +550,7 @@ async def bookmark_tweet(tweet_id: str, folder_id: str | None = None) -> str:
     result: dict = {"tweet_id": tweet_id, "status": "bookmarked"}
     if folder_id is not None:
         result["folder_id"] = folder_id
-    return json.dumps(result)
+    return _dumps(result)
 
 
 @mcp.tool()
@@ -551,7 +567,7 @@ async def delete_bookmark(tweet_id: str) -> str:
         raise ToolError(f"X rate limit exceeded; retry later. ({e})")
     except NotFound:
         raise ToolError(f"Bookmark for tweet {tweet_id} not found.")
-    return json.dumps({"tweet_id": tweet_id, "status": "un-bookmarked"})
+    return _dumps({"tweet_id": tweet_id, "status": "un-bookmarked"})
 
 
 @mcp.tool()
@@ -583,7 +599,7 @@ async def get_bookmarks(count: int = 20, cursor: str | None = None) -> str:
         }
         for t in result
     ]
-    return json.dumps(
+    return _dumps(
         {
             "tweets": tweets,
             "next_cursor": getattr(result, "next_cursor", None),
@@ -617,7 +633,7 @@ async def get_favoriters(
     except NotFound:
         raise ToolError(f"Tweet {tweet_id} not found.")
     users = [_user_to_dict(u) for u in result]
-    return json.dumps(
+    return _dumps(
         {
             "users": users,
             "next_cursor": getattr(result, "next_cursor", None),
@@ -651,7 +667,7 @@ async def get_retweeters(
     except NotFound:
         raise ToolError(f"Tweet {tweet_id} not found.")
     users = [_user_to_dict(u) for u in result]
-    return json.dumps(
+    return _dumps(
         {
             "users": users,
             "next_cursor": getattr(result, "next_cursor", None),
@@ -683,7 +699,7 @@ async def search_user(query: str, count: int = 20, cursor: str | None = None) ->
     except TooManyRequests as e:
         raise ToolError(f"X rate limit exceeded; retry later. ({e})")
     users = [_user_to_dict(u) for u in result]
-    return json.dumps(
+    return _dumps(
         {
             "users": users,
             "next_cursor": getattr(result, "next_cursor", None),
@@ -720,7 +736,7 @@ async def get_trends(category: str = "trending", count: int = 20) -> str:
         }
         for t in trends
     ]
-    return json.dumps({"trends": result, "category": category})
+    return _dumps({"trends": result, "category": category})
 
 
 @mcp.tool()
@@ -745,7 +761,7 @@ async def get_article_preview(tweet_id: str) -> str:
     if not article:
         raise ToolError(f"Tweet {tweet_id} does not embed an article.")
     cover = article.get("cover_media", {}).get("media_info", {}).get("original_img_url")
-    return json.dumps(
+    return _dumps(
         {
             "rest_id": article["rest_id"],
             "title": article.get("title", ""),
@@ -836,7 +852,7 @@ async def get_article(article_id: str, format: str = "plain") -> str:
         )
 
     if format == "full":
-        return json.dumps(article, ensure_ascii=False)
+        return _dumps(article)
 
     cover = article.get("cover_media", {}).get("media_info", {}).get("original_img_url")
 
@@ -866,7 +882,7 @@ async def get_article(article_id: str, format: str = "plain") -> str:
             "media": media,
             "lifecycle_state": article.get("lifecycle_state"),
         }
-    return json.dumps(out, ensure_ascii=False)
+    return _dumps(out)
 
 
 _VALID_NOTIFICATION_TYPES = frozenset({"All", "Verified", "Mentions"})
@@ -890,9 +906,7 @@ async def block_user(screen_name: str) -> str:
         raise ToolError(f"X rate limit exceeded; retry later. ({e})")
     except NotFound:
         raise ToolError(f"User not found: {screen_name}.")
-    return json.dumps(
-        {"user_id": user.id, "screen_name": screen_name, "status": "blocked"}
-    )
+    return _dumps({"user_id": user.id, "screen_name": screen_name, "status": "blocked"})
 
 
 @mcp.tool()
@@ -913,7 +927,7 @@ async def unblock_user(screen_name: str) -> str:
         raise ToolError(f"X rate limit exceeded; retry later. ({e})")
     except NotFound:
         raise ToolError(f"User not found: {screen_name}.")
-    return json.dumps(
+    return _dumps(
         {"user_id": user.id, "screen_name": screen_name, "status": "unblocked"}
     )
 
@@ -936,9 +950,7 @@ async def mute_user(screen_name: str) -> str:
         raise ToolError(f"X rate limit exceeded; retry later. ({e})")
     except NotFound:
         raise ToolError(f"User not found: {screen_name}.")
-    return json.dumps(
-        {"user_id": user.id, "screen_name": screen_name, "status": "muted"}
-    )
+    return _dumps({"user_id": user.id, "screen_name": screen_name, "status": "muted"})
 
 
 @mcp.tool()
@@ -959,9 +971,7 @@ async def unmute_user(screen_name: str) -> str:
         raise ToolError(f"X rate limit exceeded; retry later. ({e})")
     except NotFound:
         raise ToolError(f"User not found: {screen_name}.")
-    return json.dumps(
-        {"user_id": user.id, "screen_name": screen_name, "status": "unmuted"}
-    )
+    return _dumps({"user_id": user.id, "screen_name": screen_name, "status": "unmuted"})
 
 
 @mcp.tool()
@@ -1008,7 +1018,7 @@ async def get_notifications(
             entry["tweet_id"] = n.tweet.id
         notifications.append(entry)
 
-    return json.dumps(
+    return _dumps(
         {
             "notifications": notifications,
             "next_cursor": getattr(result, "next_cursor", None),
@@ -1039,7 +1049,7 @@ async def send_dm(screen_name: str, text: str, media_id: str | None = None) -> s
         raise ToolError(f"X rate limit exceeded; retry later. ({e})")
     except NotFound:
         raise ToolError(f"User not found: {screen_name}.")
-    return json.dumps({"message_id": message.id, "status": "sent"})
+    return _dumps({"message_id": message.id, "status": "sent"})
 
 
 @mcp.tool()
@@ -1065,7 +1075,7 @@ async def send_dm_to_group(
         raise ToolError(f"X rate limit exceeded; retry later. ({e})")
     except NotFound:
         raise ToolError(f"Group {group_id!r} not found.")
-    return json.dumps({"message_id": message.id, "status": "sent"})
+    return _dumps({"message_id": message.id, "status": "sent"})
 
 
 @mcp.tool()
@@ -1100,7 +1110,7 @@ async def get_dm_history(screen_name: str, max_id: str | None = None) -> str:
         }
         for m in result
     ]
-    return json.dumps(
+    return _dumps(
         {
             "messages": messages,
             "next_cursor": getattr(result, "next_cursor", None),
@@ -1125,7 +1135,7 @@ async def delete_dm(message_id: str) -> str:
         raise ToolError(f"X rate limit exceeded; retry later. ({e})")
     except NotFound:
         raise ToolError(f"Message {message_id} not found.")
-    return json.dumps({"message_id": message_id, "status": "deleted"})
+    return _dumps({"message_id": message_id, "status": "deleted"})
 
 
 def _list_to_dict(lst) -> dict:
@@ -1194,7 +1204,7 @@ async def get_list(list_id: str) -> str:
         raise ToolError(f"X rate limit exceeded; retry later. ({e})")
     except NotFound:
         raise ToolError(f"List {list_id} not found.")
-    return json.dumps(_list_to_dict(lst))
+    return _dumps(_list_to_dict(lst))
 
 
 @mcp.tool()
@@ -1217,7 +1227,7 @@ async def get_lists(count: int = 20, cursor: str | None = None) -> str:
     except TooManyRequests as e:
         raise ToolError(f"X rate limit exceeded; retry later. ({e})")
     lists = [_list_to_dict(lst) for lst in result]
-    return json.dumps(
+    return _dumps(
         {
             "lists": lists,
             "next_cursor": getattr(result, "next_cursor", None),
@@ -1260,7 +1270,7 @@ async def get_list_tweets(
         }
         for t in result
     ]
-    return json.dumps(
+    return _dumps(
         {
             "tweets": tweets,
             "next_cursor": getattr(result, "next_cursor", None),
@@ -1294,7 +1304,7 @@ async def get_list_members(
     except NotFound:
         raise ToolError(f"List {list_id} not found.")
     users = [_user_to_dict(u) for u in result]
-    return json.dumps(
+    return _dumps(
         {
             "users": users,
             "next_cursor": getattr(result, "next_cursor", None),
@@ -1328,7 +1338,7 @@ async def get_list_subscribers(
     except NotFound:
         raise ToolError(f"List {list_id} not found.")
     users = [_user_to_dict(u) for u in result]
-    return json.dumps(
+    return _dumps(
         {
             "users": users,
             "next_cursor": getattr(result, "next_cursor", None),
@@ -1355,7 +1365,7 @@ async def create_list(
         lst = await client.create_list(name, description, is_private)
     except TooManyRequests as e:
         raise ToolError(f"X rate limit exceeded; retry later. ({e})")
-    return json.dumps(_list_to_dict(lst))
+    return _dumps(_list_to_dict(lst))
 
 
 @mcp.tool()
@@ -1385,7 +1395,7 @@ async def edit_list(
         raise ToolError(f"X rate limit exceeded; retry later. ({e})")
     except NotFound:
         raise ToolError(f"List {list_id} not found.")
-    return json.dumps(_list_to_dict(lst))
+    return _dumps(_list_to_dict(lst))
 
 
 @mcp.tool()
@@ -1412,7 +1422,7 @@ async def add_list_member(
         raise ToolError(f"X rate limit exceeded; retry later. ({e})")
     except NotFound:
         raise ToolError(f"Not found: list {list_id} or user {screen_name or user_id}.")
-    return json.dumps(_list_to_dict(lst))
+    return _dumps(_list_to_dict(lst))
 
 
 @mcp.tool()
@@ -1439,7 +1449,7 @@ async def remove_list_member(
         raise ToolError(f"X rate limit exceeded; retry later. ({e})")
     except NotFound:
         raise ToolError(f"Not found: list {list_id} or user {screen_name or user_id}.")
-    return json.dumps(_list_to_dict(lst))
+    return _dumps(_list_to_dict(lst))
 
 
 @mcp.tool()
@@ -1468,7 +1478,7 @@ async def create_scheduled_tweet(
         tweet_id = await client.create_scheduled_tweet(scheduled_at, text, media_ids)
     except TooManyRequests as e:
         raise ToolError(f"X rate limit exceeded; retry later. ({e})")
-    return json.dumps(
+    return _dumps(
         {
             "scheduled_tweet_id": tweet_id,
             "scheduled_at": scheduled_at,
@@ -1502,7 +1512,7 @@ async def get_scheduled_tweets() -> str:
         }
         for t in tweets
     ]
-    return json.dumps({"scheduled_tweets": result, "count": len(result)})
+    return _dumps({"scheduled_tweets": result, "count": len(result)})
 
 
 @mcp.tool()
@@ -1524,7 +1534,7 @@ async def delete_scheduled_tweet(scheduled_tweet_id: str) -> str:
         raise ToolError(f"X rate limit exceeded; retry later. ({e})")
     except NotFound:
         raise ToolError(f"Scheduled tweet {scheduled_tweet_id} not found.")
-    return json.dumps({"scheduled_tweet_id": scheduled_tweet_id, "status": "deleted"})
+    return _dumps({"scheduled_tweet_id": scheduled_tweet_id, "status": "deleted"})
 
 
 @mcp.tool()
@@ -1558,7 +1568,7 @@ async def create_poll(choices: list[str], duration_minutes: int) -> str:
         card_uri = await client.create_poll(choices, duration_minutes)
     except TooManyRequests as e:
         raise ToolError(f"X rate limit exceeded; retry later. ({e})")
-    return json.dumps({"card_uri": card_uri, "status": "created"})
+    return _dumps({"card_uri": card_uri, "status": "created"})
 
 
 @mcp.tool()
@@ -1594,7 +1604,7 @@ async def vote(
         raise ToolError(f"X rate limit exceeded; retry later. ({e})")
     except NotFound:
         raise ToolError(f"Tweet {tweet_id} or poll card not found.")
-    return json.dumps(
+    return _dumps(
         {"tweet_id": tweet_id, "selected_choice": selected_choice, "status": "voted"}
     )
 
@@ -1615,7 +1625,7 @@ async def get_community(community_id: str) -> str:
         raise ToolError(f"X rate limit exceeded; retry later. ({e})")
     except NotFound:
         raise ToolError(f"Community {community_id} not found.")
-    return json.dumps(_community_to_dict(community))
+    return _dumps(_community_to_dict(community))
 
 
 @mcp.tool()
@@ -1636,7 +1646,7 @@ async def search_community(query: str, cursor: str | None = None) -> str:
     except TooManyRequests as e:
         raise ToolError(f"X rate limit exceeded; retry later. ({e})")
     communities = [_community_to_dict(c) for c in result]
-    return json.dumps(
+    return _dumps(
         {
             "communities": communities,
             "next_cursor": getattr(result, "next_cursor", None),
@@ -1692,7 +1702,7 @@ async def get_community_tweets(
         }
         for t in result
     ]
-    return json.dumps(
+    return _dumps(
         {
             "tweets": tweets,
             "next_cursor": getattr(result, "next_cursor", None),
@@ -1730,7 +1740,7 @@ async def get_communities_timeline(count: int = 20, cursor: str | None = None) -
         }
         for t in result
     ]
-    return json.dumps(
+    return _dumps(
         {
             "tweets": tweets,
             "next_cursor": getattr(result, "next_cursor", None),
@@ -1766,7 +1776,7 @@ async def get_community_members(
     except NotFound:
         raise ToolError(f"Community {community_id} not found.")
     members = [_community_member_to_dict(m) for m in result]
-    return json.dumps(
+    return _dumps(
         {
             "members": members,
             "next_cursor": getattr(result, "next_cursor", None),
@@ -1802,7 +1812,7 @@ async def get_community_moderators(
     except NotFound:
         raise ToolError(f"Community {community_id} not found.")
     moderators = [_community_member_to_dict(m) for m in result]
-    return json.dumps(
+    return _dumps(
         {
             "moderators": moderators,
             "next_cursor": getattr(result, "next_cursor", None),
@@ -1853,7 +1863,7 @@ async def search_community_tweet(
         }
         for t in result
     ]
-    return json.dumps(
+    return _dumps(
         {
             "tweets": tweets,
             "next_cursor": getattr(result, "next_cursor", None),
@@ -1878,7 +1888,7 @@ async def join_community(community_id: str) -> str:
         raise ToolError(f"X rate limit exceeded; retry later. ({e})")
     except NotFound:
         raise ToolError(f"Community {community_id} not found.")
-    return json.dumps({**_community_to_dict(community), "status": "joined"})
+    return _dumps({**_community_to_dict(community), "status": "joined"})
 
 
 @mcp.tool()
@@ -1897,7 +1907,7 @@ async def leave_community(community_id: str) -> str:
         raise ToolError(f"X rate limit exceeded; retry later. ({e})")
     except NotFound:
         raise ToolError(f"Community {community_id} not found.")
-    return json.dumps({**_community_to_dict(community), "status": "left"})
+    return _dumps({**_community_to_dict(community), "status": "left"})
 
 
 @mcp.tool()
@@ -1923,7 +1933,7 @@ async def request_to_join_community(
         raise ToolError(f"X rate limit exceeded; retry later. ({e})")
     except NotFound:
         raise ToolError(f"Community {community_id} not found.")
-    return json.dumps({"community_id": community_id, "status": "request_sent"})
+    return _dumps({"community_id": community_id, "status": "request_sent"})
 
 
 def _get_version() -> str:
@@ -2027,6 +2037,144 @@ def _parse_kv_pairs(items: list[str]) -> dict[str, str]:
     return out
 
 
+# ── Human-friendly CLI formatters ─────────────────────
+#
+# These are used by the `tweet` / `user` / `tl` / `search` / `trends`
+# subcommands. They take the tool's already-decoded dict (or list-of-
+# dicts) output and render plain text for terminal reading. No external
+# deps (no `rich` etc.) — keeps install tiny.
+
+
+def _compact_num(n) -> str:
+    """1234567 → '1.2M' / 12500 → '12.5K' / small numbers unchanged."""
+    try:
+        n = int(n)
+    except (TypeError, ValueError):
+        return str(n)
+    if n >= 1_000_000_000:
+        return f"{n / 1_000_000_000:.1f}B"
+    if n >= 1_000_000:
+        return f"{n / 1_000_000:.1f}M"
+    if n >= 10_000:
+        return f"{n / 1_000:.1f}K"
+    return f"{n:,}"
+
+
+def _format_tweet(t: dict) -> str:
+    """One tweet block, terminal-readable. Fields tolerated as missing."""
+    author = t.get("author", "?")
+    name = t.get("author_name", "")
+    header = f"@{author}" + (f" · {name}" if name else "")
+    text = (t.get("text") or "").strip()
+    created = t.get("created_at", "")
+    likes = _compact_num(t.get("likes", 0))
+    rts = _compact_num(t.get("retweets", 0))
+    tid = t.get("id", "")
+    url = f"https://x.com/{author}/status/{tid}" if author and tid else ""
+    parts = [header, text, f"❤ {likes}  🔁 {rts}  · {created}"]
+    if url:
+        parts.append(url)
+    return "\n".join(p for p in parts if p)
+
+
+def _format_tweet_list(tweets: list[dict]) -> str:
+    """Numbered tweets separated by blank lines."""
+    if not tweets:
+        return "(no tweets)"
+    blocks = []
+    for i, t in enumerate(tweets, 1):
+        blocks.append(f"[{i}] " + _format_tweet(t))
+    return "\n\n".join(blocks)
+
+
+def _format_user(u: dict) -> str:
+    """One user profile block."""
+    sn = u.get("screen_name", "?")
+    name = u.get("name", "")
+    verified = "✓" if u.get("is_blue_verified") or u.get("verified") else ""
+    header = f"@{sn}" + (f" · {name}" if name else "")
+    if verified:
+        header += f" {verified}"
+    desc = (u.get("description") or "").strip()
+    fc = _compact_num(u.get("followers_count", 0))
+    fg = _compact_num(u.get("following_count", 0))
+    tw = _compact_num(u.get("tweets_count", 0))
+    location = u.get("location") or ""
+    url = u.get("url") or ""
+    created = u.get("created_at", "")
+    line2 = f"Followers: {fc}   Following: {fg}   Posts: {tw}"
+    line3_bits = []
+    if location:
+        line3_bits.append(f"📍 {location}")
+    if created:
+        line3_bits.append(f"Joined: {created}")
+    parts = [header, desc, line2]
+    if line3_bits:
+        parts.append("   ".join(line3_bits))
+    parts.append(f"https://x.com/{sn}")
+    if url:
+        parts.append(f"Link: {url}")
+    return "\n".join(p for p in parts if p)
+
+
+def _format_trends(payload: dict) -> str:
+    """Numbered trend list."""
+    trends = payload.get("trends") or []
+    if not trends:
+        return "(no trends)"
+    out = []
+    for i, t in enumerate(trends, 1):
+        nm = t.get("name", "?")
+        cnt = t.get("tweets_count")
+        ctx = t.get("domain_context") or ""
+        line = f"{i:>2}. {nm}"
+        if cnt:
+            line += f"  ({_compact_num(cnt)} tweets)"
+        if ctx:
+            line += f"  — {ctx}"
+        out.append(line)
+    return "\n".join(out)
+
+
+async def _human_tweet(id_or_url: str) -> str:
+    raw = await _call_tool_async("get_tweet", {"tweet_id": id_or_url})
+    import json as _stdlib_json
+
+    return _format_tweet(_stdlib_json.loads(raw))
+
+
+async def _human_user(screen_name: str) -> str:
+    raw = await _call_tool_async("get_user_info", {"screen_name": screen_name})
+    import json as _stdlib_json
+
+    return _format_user(_stdlib_json.loads(raw))
+
+
+async def _human_timeline(count: int) -> str:
+    raw = await _call_tool_async("get_timeline", {"count": str(count)})
+    import json as _stdlib_json
+
+    return _format_tweet_list(_stdlib_json.loads(raw))
+
+
+async def _human_search(query: str, count: int) -> str:
+    raw = await _call_tool_async(
+        "search_tweets", {"query": query, "count": str(count), "product": "Top"}
+    )
+    import json as _stdlib_json
+
+    return _format_tweet_list(_stdlib_json.loads(raw))
+
+
+async def _human_trends(count: int) -> str:
+    raw = await _call_tool_async(
+        "get_trends", {"category": "trending", "count": str(count)}
+    )
+    import json as _stdlib_json
+
+    return _format_trends(_stdlib_json.loads(raw))
+
+
 def main():
     parser = argparse.ArgumentParser(
         prog="twikit-mcp",
@@ -2070,6 +2218,51 @@ def main():
         help="Zero or more arguments in key=value form.",
     )
 
+    # ── Human-friendly subcommands ────────────────────
+    # Same underlying tools as `call`, but with positional args + pretty
+    # text output (no raw JSON). For when you want to read X in the shell.
+    p_tweet = sub.add_parser(
+        "tweet",
+        help="Pretty-print a single tweet by ID or URL.",
+        description="Example: twikit-mcp tweet 20",
+    )
+    p_tweet.add_argument("id_or_url", help="Tweet ID (numeric) or full x.com URL.")
+
+    p_user = sub.add_parser(
+        "user",
+        help="Pretty-print a user's profile.",
+        description="Example: twikit-mcp user elonmusk",
+    )
+    p_user.add_argument("screen_name", help="Twitter username (without @).")
+
+    p_tl = sub.add_parser(
+        "tl",
+        help="Pretty-print your home timeline (cookie identity).",
+        description="Example: twikit-mcp tl 10",
+    )
+    p_tl.add_argument(
+        "count", nargs="?", default=20, type=int, help="Number of tweets (default 20)."
+    )
+
+    p_search = sub.add_parser(
+        "search",
+        help="Pretty-print Top search results.",
+        description='Example: twikit-mcp search "AI" 5',
+    )
+    p_search.add_argument("query", help="Search query string.")
+    p_search.add_argument(
+        "count", nargs="?", default=10, type=int, help="Number of results (default 10)."
+    )
+
+    p_trends = sub.add_parser(
+        "trends",
+        help="Pretty-print global trending topics.",
+        description="Example: twikit-mcp trends 10",
+    )
+    p_trends.add_argument(
+        "count", nargs="?", default=20, type=int, help="Number of trends (default 20)."
+    )
+
     args = parser.parse_args()
 
     if args.cmd == "list":
@@ -2080,6 +2273,24 @@ def main():
         kwargs = _parse_kv_pairs(args.kwargs)
         try:
             out = asyncio.run(_call_tool_async(args.tool, kwargs))
+        except ToolError as e:
+            print(f"Error: {e}", file=sys.stderr)
+            raise SystemExit(2)
+        print(out)
+        return
+
+    # Human-friendly read paths. All share the same ToolError → stderr +
+    # exit-2 handling as `call`.
+    _human_dispatch = {
+        "tweet": lambda a: _human_tweet(a.id_or_url),
+        "user": lambda a: _human_user(a.screen_name),
+        "tl": lambda a: _human_timeline(a.count),
+        "search": lambda a: _human_search(a.query, a.count),
+        "trends": lambda a: _human_trends(a.count),
+    }
+    if args.cmd in _human_dispatch:
+        try:
+            out = asyncio.run(_human_dispatch[args.cmd](args))
         except ToolError as e:
             print(f"Error: {e}", file=sys.stderr)
             raise SystemExit(2)


### PR DESCRIPTION
## Summary

Closes #52. Two related CLI ergonomic fixes shipped together:

1. **UTF-8 JSON output** — every tool output preserves native non-ASCII (Greek / 中文 / 日本語 / emoji). Was escaping to `\uXXXX` everywhere.
2. **Human-friendly subcommands** — `tweet` / `user` / `tl` / `search` / `trends` for reading X in your terminal, with positional args + plain text output.

See the issue body for the full spec, acceptance criteria, and design rationale.

## What changed

| File | Change |
|---|---|
| `twitter_mcp/server.py` | Added `_dumps()` helper (project-wide UTF-8 JSON); 60 `json.dumps(` → `_dumps(`. Added 5 formatters + 5 human-CLI dispatchers + 5 argparse subparsers. |
| `tests/test_cli.py` | +19 tests: `_compact_num`, all 4 formatters incl. unicode regression, subprocess help advert, dispatcher unit tests. |
| `README.md` | CLI section rewritten with 3 modes (MCP / human / machine). |
| `docs/cli.{en,zh,ja}.md` | Same restructure, three languages. |

## Self-validating

This is the first PR on the new flow with **MERGE_PAT presumably set**. If it auto-merges + cascades to a docs.yml redeploy without me clicking anything, full autonomy is confirmed end-to-end.

## Acceptance criteria (from #52)

- [x] Native UTF-8 in all tool outputs
- [x] Greek-tweet regression test (`test_tool_output_preserves_unicode_raw`)
- [x] 5 human subcommands + positional args + plain-text output
- [x] Backward compat — `serve` / `list` / `call` unchanged
- [x] No new deps (no rich / click)
- [x] 540 tests pass; `server.py` 100% coverage; `--cov-fail-under=95`
- [x] README + docs in 3 languages updated

## Spec / SDD checklist

- [x] No new MCP tool (formatters wrap existing tools)
- [x] No test fixture changes
- [x] No vendor patches
- [x] No live-smoke validators
- [x] Tool count unchanged (still 57)

## Note: spec-first discipline

I retrofitted #52 into a real spec issue **after** writing the code. From the next PR onward I'll go issue-first: spec → red test → green fix → docs+chore commit, exactly per the workflow you flagged.

https://claude.ai/code/session_01YZ5NXtFwvf3yybuRVSzvPY

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZ5NXtFwvf3yybuRVSzvPY)_