### PR TITLE
ci: simplify PR pipeline — MiniMax advisory, CC drives merge (closes #54)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,52 +72,8 @@ jobs:
             | uv run python -m twitter_mcp.server \
             | uv run python -c "import json, sys; resp = json.loads(sys.stdin.readline()); assert resp['result']['serverInfo']['name'] == 'twitter'; print('MCP handshake OK')"
 
-  # ─── PR auto-fix loop ───
-  # When ANY of the gating jobs (lint/test×3/protocol) fails on a PR, this
-  # job auto-summons @claude with iter cap of 5 + escalation to issue (same
-  # cap logic as pr-review.yml's request-changes path). Doesn't run on
-  # push-to-main fails — those go straight to the live-smoke / publish
-  # error paths.
-  ci-failure-auto-fix:
-    name: Auto-summon @claude on CI failure
-    needs: [lint, test, protocol]
-    if: always() && github.event_name == 'pull_request' && (needs.lint.result == 'failure' || needs.test.result == 'failure' || needs.protocol.result == 'failure')
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-      issues: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Build failure summary
-        env:
-          LINT: ${{ needs.lint.result }}
-          TEST: ${{ needs.test.result }}
-          PROTO: ${{ needs.protocol.result }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          {
-            echo "**Failed CI jobs:**"
-            [ "$LINT" = "failure" ]  && echo "- ❌ Lint & Format"
-            [ "$TEST" = "failure" ]  && echo "- ❌ Test (Python 3.14, one or more platforms)"
-            [ "$PROTO" = "failure" ] && echo "- ❌ MCP Protocol Check"
-            echo
-            echo "Run: $RUN_URL"
-            echo
-            echo "_(Workflow logs aren't readable from MCP — open the run URL above to see the failing step's output. Common patterns:)_"
-            echo "- **Lint** → \`uv run ruff format .\` + \`uv run ruff check . --fix\`"
-            echo "- **Test** → run \`uv run pytest -x -q\` locally; an assertion / import / coverage drop will be in the output"
-            echo "- **MCP Protocol** → \`uv run python -m twitter_mcp.server\` should respond to a JSON-RPC initialize within seconds; fails usually mean a \`server.py\` import error"
-          } > failure.md
-
-      - name: Auto-summon @claude
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          PR_NUM: ${{ github.event.pull_request.number }}
-          REASON: "CI failure"
-          BODY_FILE: failure.md
-        run: bash .github/scripts/auto_summon_claude.sh
+# Issue #54: the auto-fix-on-CI-fail job that previously lived here was
+# removed. CI failures show up directly on the PR; the maintainer (via
+# Claude Code) decides whether to push a fix or close the PR. The
+# `auto_summon_claude.sh` helper is still in the tree because live-smoke
+# uses it — that loop stays as a post-release safety net.

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,20 +1,18 @@
 name: PR review (MiniMax M2)
 
-# Per-PR automated review by MiniMax M2 via OpenAI-compatible
-# api.minimaxi.com endpoint. Originally swapped in via PR #42 (replacing
-# anthropics/claude-code-action). Major v2 changes (this revision):
+# Per-PR ADVISORY review by MiniMax M2 via OpenAI-compatible
+# api.minimaxi.com endpoint. Issue #54 — this workflow only POSTS a review
+# comment; merging and code fixes are the maintainer's call (driven via
+# Claude Code session + `mcp__github__merge_pull_request`).
 #
-#   1. JSON-mode output (`response_format: {"type": "json_object"}`) so
-#      the Decision is a top-level field — no more grep-the-markdown.
-#   2. Post-review action: when decision is `request-changes`, auto-summon
-#      `@claude` with iter cap of 5 + escalation issue (.github/scripts/
-#      auto_summon_claude.sh handles the cap logic).
-#   3. When decision is `approve`/`comment`, enable GitHub native
-#      auto-merge — the PR merges as soon as required CI checks pass.
+# Why MiniMax for review specifically:
+#   - review is the highest-frequency LLM call in this repo (every PR
+#     open / synchronize / reopen / ready_for_review), and tokens add up;
+#     M2 is ~10x cheaper than Sonnet at comparable critique quality.
+#   - review is text-out only, so the OpenAI-compat endpoint covers fine.
 #
-# `@claude` mentions in `claude.yml` stay on Anthropic — those need
-# Claude Code's tool-using session to actually edit/commit/push, which
-# OpenAI-compat M2 has no equivalent for.
+# Coding (the actual edits) stays on Claude Code via `claude.yml`'s
+# `@claude` mention handler — quality matters more than cost there.
 
 on:
   pull_request:
@@ -26,15 +24,8 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  # `contents: write` is needed for the auto-merge step at the bottom of
-  # this workflow — `gh pr merge --auto --squash` uses the GraphQL
-  # `enableAutoMerge` mutation, which then asks GitHub itself to push
-  # the merge commit using the workflow's GITHUB_TOKEN. Without write,
-  # the merge silently fails after auto-merge "enables". Same for the
-  # direct-merge fallback.
-  contents: write
-  pull-requests: write
-  issues: write   # used by auto_summon_claude.sh to open escalation issues
+  contents: read
+  pull-requests: write   # post the review comment
 
 jobs:
   review:
@@ -294,67 +285,7 @@ jobs:
             cat review.md
             echo
             echo "---"
-            echo "_Automated review. \`request-changes\` triggers an auto-fix loop (cap 5); \`approve\` / \`comment\` triggers GitHub auto-merge once required CI checks are green._"
+            echo "_Advisory review by MiniMax M2 — the maintainer (via Claude Code) reads this and decides whether to push fixes or merge. Decision values are informational only; this workflow does **not** auto-merge or auto-summon @claude. To request a code change, mention \`@claude\` in a comment._"
           } > final.md
 
           gh pr comment "$PR_NUM" --body-file final.md
-
-      # ─── Post-review action: auto-fix loop OR auto-merge ───
-      - name: Auto-summon @claude (decision = request-changes)
-        if: steps.parse.outputs.decision == 'request-changes'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          PR_NUM: ${{ github.event.pull_request.number }}
-          REASON: "MiniMax review"
-          BODY_FILE: review.md
-        run: bash .github/scripts/auto_summon_claude.sh
-
-      - name: Enable auto-merge → fall back to direct merge (decision = approve | comment)
-        if: steps.parse.outputs.decision == 'approve' || steps.parse.outputs.decision == 'comment'
-        env:
-          # IMPORTANT: prefer MERGE_PAT over GITHUB_TOKEN for the merge.
-          #
-          # GitHub's anti-loop protection: pushes (and tag pushes) made by
-          # GITHUB_TOKEN do NOT trigger downstream workflows. So when this
-          # step uses GITHUB_TOKEN to merge, the resulting push to `main`
-          # is invisible to publish.yml — the new release never ships.
-          #
-          # MERGE_PAT (a fine-grained Personal Access Token with
-          # contents:write + pull_requests:write on this repo) bypasses
-          # that limit: PAT-initiated pushes DO cascade to publish.yml +
-          # docs.yml + ci.yml as expected.
-          #
-          # If the secret isn't set, fall back to GITHUB_TOKEN — merge
-          # still happens, just no downstream cascade. The maintainer
-          # would have to trigger publish.yml manually each release.
-          GH_TOKEN: ${{ secrets.MERGE_PAT || secrets.GITHUB_TOKEN }}
-          PR_NUM: ${{ github.event.pull_request.number }}
-        run: |
-          # GitHub's `--auto` flag only enables auto-merge if the PR has at
-          # least one *pending* required check (i.e. branch protection has
-          # required statuses configured AND at least one isn't green yet).
-          # When a repo has no branch protection (or no required statuses),
-          # `--auto` rejects with "Pull Request is in clean status" — there's
-          # nothing for it to wait on. In that case we fall back to a direct
-          # merge: if the PR is mergeable right now, just merge it.
-          #
-          # Both paths skip / warn instead of failing the workflow, since
-          # auto-merge is best-effort.
-          if [ -z "${{ secrets.MERGE_PAT }}" ]; then
-            echo "::warning::MERGE_PAT not set; falling back to GITHUB_TOKEN. Downstream workflows (publish.yml / docs.yml) will NOT auto-trigger after merge — releases require a manual workflow_dispatch. See README for the one-time PAT setup."
-          fi
-
-          if gh pr merge --auto --squash --delete-branch "$PR_NUM" 2>&1; then
-            echo "Auto-merge enabled — GitHub will merge once required checks pass."
-            exit 0
-          fi
-
-          echo "::notice::Auto-merge enable refused (likely: no pending required checks). Trying direct merge."
-
-          if gh pr merge --squash --delete-branch "$PR_NUM" 2>&1; then
-            echo "Direct merge succeeded — PR is now closed."
-            exit 0
-          fi
-
-          echo "::warning::Both auto-merge enable and direct merge failed. PR stays open for manual handling. Likely causes: (a) 'Allow auto-merge' disabled in repo Settings → General; (b) branch protection requires reviewers; (c) PR has merge conflicts."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -252,3 +252,32 @@ def test_tools_registered():
     }
     assert set(tools.keys()) == expected
 ```
+
+---
+
+## PR pipeline(issue #54 简化后)
+
+每个 PR 上跑这几条流水线,**全部为 advisory(顾问性)**,不再有 workflow 自动 merge / auto-summon。
+
+```
+PR open / push
+  ├─ ci.yml          → lint + 3 平台 test + MCP protocol(决定能不能合)
+  └─ pr-review.yml   → MiniMax M2 拉个 review,post 成评论(顾问)
+
+  ↓
+maintainer(在 Claude Code session 里)
+  ├─ 读 review,挑出真问题(忽略误报 / bikeshed)
+  ├─ 真问题 → 自己 push 修复 → 触发新一轮 review,最多 5 轮
+  ├─ 5 轮还 request-changes → 开 issue 记录现状 → 停手(或人工 escalate)
+  └─ 没问题 / 价值低 → 用 mcp__github__merge_pull_request 合
+                       → push 走 maintainer token,自然 cascade
+                       → publish.yml + docs.yml 自动跑(版本变了就发 PyPI;docs 路径变了就 redeploy)
+```
+
+为什么这样:
+- review = MiniMax(便宜 + 频繁,~$0.01/PR)
+- coding = Claude Code(在 session 里写,质量优先)
+- merge = Claude Code 用 mcp 工具(走你 token,GitHub 不会拦截 cascade)
+- 不需要 PAT,不需要 branch protection 上的特殊配置
+
+什么时候手动召唤 `@claude`?当你想让 bot session 接活(写代码、改 docs、跑命令)而不想自己写。在 issue 或 PR 评论里 `@claude please ...`,`claude.yml` 接管。

--- a/tests/test_workflow_simplified.py
+++ b/tests/test_workflow_simplified.py
@@ -1,0 +1,115 @@
+"""Workflow-content guards for issue #54 simplification.
+
+The PR pipeline policy (per issue #54): MiniMax review is purely
+advisory; CC + maintainer drive merge via mcp__github__merge_pull_request.
+The workflow-side auto-merge / auto-summon-@claude steps are removed.
+
+These tests assert the workflow YAML does NOT regrow those steps. If a
+future refactor reintroduces them, the failure message names the
+specific section so the regression is unambiguous.
+"""
+
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).parent.parent
+_PR_REVIEW = _ROOT / ".github/workflows/pr-review.yml"
+_CI = _ROOT / ".github/workflows/ci.yml"
+
+
+# Sentinels: distinctive substrings from the removed steps. We grep for
+# these instead of parsing yaml because the failure mode we care about is
+# "someone copy-pasted the old step back in", which substring grep catches
+# directly.
+_AUTO_MERGE_SENTINELS = (
+    "gh pr merge --auto --squash",
+    "Enable auto-merge",
+)
+_AUTO_SUMMON_SENTINELS = (
+    "Auto-summon @claude",
+    "auto_summon_claude.sh",
+)
+_CI_FAILURE_SENTINELS = (
+    "ci-failure-auto-fix",
+    "Auto-summon @claude on CI failure",
+)
+
+
+@pytest.mark.parametrize("sentinel", _AUTO_MERGE_SENTINELS)
+def test_pr_review_has_no_auto_merge_step(sentinel: str):
+    """pr-review.yml must NOT contain the workflow-side auto-merge step.
+
+    Issue #54: merging is the maintainer's call (via
+    mcp__github__merge_pull_request). The workflow only posts a review.
+    """
+    src = _PR_REVIEW.read_text()
+    assert sentinel not in src, (
+        f"pr-review.yml contains {sentinel!r} — the workflow-side auto-merge "
+        f"step is supposed to be removed (issue #54). MiniMax review is "
+        f"advisory; CC merges manually."
+    )
+
+
+@pytest.mark.parametrize("sentinel", _AUTO_SUMMON_SENTINELS)
+def test_pr_review_does_not_auto_summon_claude(sentinel: str):
+    """pr-review.yml must NOT auto-summon @claude on `request-changes`.
+
+    Issue #54: real fixes come from CC reading the review and deciding,
+    not from the workflow firing @claude unilaterally.
+    """
+    src = _PR_REVIEW.read_text()
+    assert sentinel not in src, (
+        f"pr-review.yml contains {sentinel!r} — auto-summoning @claude "
+        f"from this workflow was removed (issue #54). `claude.yml` still "
+        f"handles manual @claude mentions; that's the maintainer's lever."
+    )
+
+
+@pytest.mark.parametrize("sentinel", _CI_FAILURE_SENTINELS)
+def test_ci_does_not_auto_fix_on_failure(sentinel: str):
+    """ci.yml must NOT contain the ci-failure-auto-fix job.
+
+    Issue #54: CI failures surface naturally on the PR; CC decides
+    whether to push a fix or close the PR.
+    """
+    src = _CI.read_text()
+    assert sentinel not in src, (
+        f"ci.yml contains {sentinel!r} — the auto-fix-on-CI-failure job "
+        f"was removed (issue #54). Failures are visible on the PR; the "
+        f"maintainer drives any fix."
+    )
+
+
+def test_pr_review_permissions_back_to_contents_read():
+    """pr-review.yml shouldn't request `contents: write` anymore.
+
+    With auto-merge removed, the workflow only needs to read the diff
+    and post a comment. Tightening back to read.
+    """
+    src = _PR_REVIEW.read_text()
+    # Crude but effective: the perms block should NOT have `contents: write`.
+    # `pull-requests: write` is still legitimate (posting the review comment).
+    assert "contents: write" not in src, (
+        "pr-review.yml requests `contents: write`; that was needed only "
+        "for the removed auto-merge step (issue #54). Back to `contents: read`."
+    )
+
+
+def test_pr_review_still_runs_minimax_review():
+    """Sanity: the productive part of pr-review.yml is intact.
+
+    We removed *only* the auto-merge / auto-summon steps. MiniMax must
+    still be called and its review posted as a PR comment.
+    """
+    src = _PR_REVIEW.read_text()
+    assert "MiniMax M2 review" in src, "pr-review.yml job name lost"
+    assert "https://api.minimaxi.com" in src, "pr-review.yml lost the MiniMax call"
+    assert "gh pr comment" in src, "pr-review.yml lost the comment-post step"
+
+
+def test_ci_still_runs_lint_test_protocol():
+    """Sanity: the productive part of ci.yml is intact."""
+    src = _CI.read_text()
+    for job in ("Lint & Format", "Test (Python", "MCP Protocol Check"):
+        assert job in src, f"ci.yml lost the {job!r} job"


### PR DESCRIPTION
## Summary

Closes #54. Reverts the workflow-side auto-merge half of PR #43; MiniMax review is now purely **advisory**.

| Layer | Before | After |
|---|---|---|
| **Review** | MiniMax M2 → JSON decision → workflow auto-acts | MiniMax M2 → JSON decision → posts comment, **no auto-action** |
| **`request-changes` path** | workflow auto-summons `@claude` (5-iter cap + escalation) | maintainer reads review, decides + pushes fixes via CC |
| **`approve` / `comment` path** | workflow `gh pr merge --auto --squash` (needs MERGE_PAT for cascade) | maintainer merges via `mcp__github__merge_pull_request` (user token cascades naturally) |
| **CI failure path** | `ci-failure-auto-fix` job auto-summons `@claude` | failures show on PR; CC decides whether to push a fix |
| **PAT** | required for cascade | **no longer needed** |

## Why

The auto-merge in `pr-review.yml` needs `MERGE_PAT` because GitHub's anti-loop protection blocks workflow-token pushes from triggering `publish.yml` / `docs.yml`. PAT setup adds real complexity for a payoff (running without CC in session) the maintainer doesn't actually want — they're in CC anyway, and CC's merge already cascades naturally (uses the user's token via MCP).

Goal stack:
1. ✅ Save review tokens (MiniMax cheap + frequent — **kept**)
2. ✅ Coding quality (CC writes the actual edits — **kept**)
3. ✅ Simple infra (no PAT, no iter-state-machine — **restored**)
4. ❌ Don't need CC in session — was never the actual goal

#3 was sacrificed in #43 / #50 to chase #4. Reverting.

## What stays automated

- `pr-review.yml` — MiniMax JSON review + comment post
- `ci.yml` — lint + 3-platform tests + MCP protocol
- `claude.yml` — manual `@claude` mentions still work
- `live-smoke.yml` + `auto_summon_claude.sh` — post-release drift safety net (issue #37 loop)
- `issue-triage.yml`, `publish.yml`, `docs.yml` — unchanged

## TDD trail (per issue #54 plan)

1. **Red** — `tests/test_workflow_simplified.py` (new): 7 sentinel-grep tests assert the removed strings are absent from yaml + 2 sanity-checks that the productive parts (MiniMax call, comment post, lint/test/protocol jobs) are intact.
2. **Green** — workflow steps removed.
3. **Docs** — `CONTRIBUTING.md` gets a new "PR pipeline" section documenting the new flow.

## Test plan

- [x] 9 new tests (`test_workflow_simplified.py`) pass
- [x] 549 total tests pass; `twitter_mcp/server.py` 100% coverage; `--cov-fail-under=95`
- [x] ruff format + check clean
- [ ] CI green on PR
- [ ] MiniMax review fires advisory-only on this PR (no auto-merge / auto-summon attempt)

## Spec / SDD checklist

- [x] No new MCP tool
- [x] No test fixture changes
- [x] No vendor patches
- [x] No live-smoke validators changed
- [x] Tool count unchanged (still 57)

## Migration note

If `MERGE_PAT` was set in repo secrets, it can now be revoked — workflow no longer references it. Branch protection settings stay as-is.

https://claude.ai/code/session_01YZ5NXtFwvf3yybuRVSzvPY

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZ5NXtFwvf3yybuRVSzvPY)_