### PR TITLE
docs: 'What's new in 0.1.22' on tri-lingual landings (closes #56)

### DIFF
--- a/docs/index.en.md
+++ b/docs/index.en.md
@@ -8,6 +8,22 @@
 
 An [MCP](https://modelcontextprotocol.io/) server that lets Claude (or any MCP-compatible AI agent) interact with Twitter/X using browser cookies. The same `twikit-mcp` binary doubles as a CLI for shell scripts and debugging.
 
+## What's new in 0.1.22
+
+- **Human-friendly CLI subcommands** — read tweets / profiles / timeline / search / trends straight from your terminal:
+
+  ```bash
+  twikit-mcp tweet 20
+  twikit-mcp user elonmusk
+  twikit-mcp tl 10
+  ```
+
+  Plain text output, native unicode, sensible defaults. See the [CLI mode page](cli.md).
+- **UTF-8 outputs end-to-end** — no more `\uXXXX` escapes. Greek / 中文 / 日本語 / emoji all flow through tools as readable text.
+- **Tri-lingual docs site** — this very page; switch language in the top bar.
+
+Upgrade with `uv tool upgrade twikit-mcp` (or `pip install --upgrade twikit-mcp`).
+
 ## What you get
 
 - **57 tools** covering tweets, users, lists, communities, scheduled tweets + polls, DMs, articles, search, trends, notifications.

--- a/docs/index.ja.md
+++ b/docs/index.ja.md
@@ -8,6 +8,22 @@
 
 [MCP](https://modelcontextprotocol.io/) サーバー — Claude(や MCP 対応の AI エージェント)がブラウザ cookies で Twitter/X を操作できます。同じ `twikit-mcp` バイナリは CLI としてもシェルスクリプトやデバッグに使えます。
 
+## 0.1.22 の新機能
+
+- **ヒューマン CLI サブコマンド** — シェルから直接ツイート / プロフィール / タイムライン / 検索 / トレンドを読めます:
+
+  ```bash
+  twikit-mcp tweet 20
+  twikit-mcp user elonmusk
+  twikit-mcp tl 10
+  ```
+
+  プレーンテキスト出力、ネイティブ Unicode、ちょうどいいデフォルト値。詳細は [CLI モード](cli.md)。
+- **エンドツーエンド UTF-8 出力** — `\uXXXX` エスケープはもうありません。中文 / 日本語 / Ελληνικά / emoji はすべて読める形でツール出力されます。
+- **三言語ドキュメントサイト** — 今ご覧のこのページ。上部で言語を切り替えてください。
+
+アップグレード:`uv tool upgrade twikit-mcp`(または `pip install --upgrade twikit-mcp`)。
+
 ## 得られるもの
 
 - **57 ツール** — ツイート、ユーザー、リスト、コミュニティ、予約投稿+投票、DM、記事、検索、トレンド、通知。

--- a/docs/index.zh.md
+++ b/docs/index.zh.md
@@ -8,6 +8,22 @@
 
 [MCP](https://modelcontextprotocol.io/) server,让 Claude(或任何 MCP 兼容的 AI agent)用浏览器 cookies 操作 Twitter/X。同一个 `twikit-mcp` 二进制还能当 CLI 用,适合 shell 脚本和调试。
 
+## 0.1.22 新增
+
+- **人用 CLI 子命令** — 直接在 shell 里读推 / 看 profile / 刷 timeline / 搜索 / 看 trends:
+
+  ```bash
+  twikit-mcp tweet 20
+  twikit-mcp user elonmusk
+  twikit-mcp tl 10
+  ```
+
+  纯文本输出,原生中日韩文,合理的默认值。详见 [CLI 模式](cli.md)。
+- **全链路 UTF-8 输出** — 不再有 `\uXXXX` 转义。中文 / 日本語 / 希腊文 / emoji 都以可读形式经过工具。
+- **三语文档站** — 你正在看的就是,顶部切换语言。
+
+升级:`uv tool upgrade twikit-mcp`(或 `pip install --upgrade twikit-mcp`)。
+
 ## 你能拿到什么
 
 - **57 个工具** — 推文、用户、列表、社群、定时推文+投票、私信、文章、搜索、趋势、通知。


### PR DESCRIPTION
## Summary

Closes #56. Adds a "What's new in 0.1.22" block to each of the three landing pages — real doc value-add + the minimum diff that triggers `docs.yml`'s path filter to redeploy the i18n site.

## Why this exists

`mkdocs-static-i18n` upgrade has been on `main` since `c8b819a` (PR #51) but the live `https://tangivis.github.io/twitter-mcp/` is **still serving the pre-i18n single-page English version**. Cause: PR #51 merged before `MERGE_PAT` was wired up, so its `push:main` event went out under `GITHUB_TOKEN` — GitHub's anti-loop protection blocked `docs.yml` from cascading. Subsequent PRs (#53, #55) didn't touch `docs/*` paths, so neither retriggered.

Code on main is correct; deploy is stale.

## Change

Each `docs/index.{en,zh,ja}.md` gets a "What's new in 0.1.22" section near the top, same content shape per language:

- Human-friendly CLI subcommands (`tweet` / `user` / `tl` / `search` / `trends`) with a 3-line bash example
- UTF-8 native output (no more `\uXXXX` escapes)
- The tri-lingual docs site itself (this page)
- Upgrade command

## Verify (local)

```
mkdocs build → 3 locale dirs (/site, /site/zh, /site/ja)
grep "What's new\|新增\|新機能" → 3 matches each, in the right files
```

## After merge (expected cascade)

```
PR merged via mcp__github__merge_pull_request (your token)
  → push:main with docs/index.{en,zh,ja}.md changed
  → docs.yml path filter hits
  → Build → deploy GitHub Pages
  → /, /zh/, /ja/ now serve the i18n site with language switcher
  → Issue #56 auto-closes
```

## Test plan

- [x] Local `mkdocs build` clean
- [x] All 3 site/{,zh/,ja/}/index.html include the new section in the right language
- [x] No code changes — 549 tests still pass / coverage gate held (no Python touched)
- [ ] CI green
- [ ] After merge: live site at `tangivis.github.io/twitter-mcp/zh/` returns 200 with 中文 content

## Spec / SDD checklist

- [x] No new MCP tool
- [x] No test fixture changes
- [x] No vendor patches
- [x] No live-smoke validators
- [x] Tool count unchanged (still 57)

https://claude.ai/code/session_01YZ5NXtFwvf3yybuRVSzvPY

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZ5NXtFwvf3yybuRVSzvPY)_