### PR TITLE
chore: bump 0.1.22 → 0.1.23 (ship ASCII Twitter cards to PyPI)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "twikit-mcp"
-version = "0.1.22"
+version = "0.1.23"
 description = "Twitter/X MCP server powered by twikit — no API key needed, free forever"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

Bumps `pyproject.toml` 0.1.22 → 0.1.23. Ships ASCII Twitter cards to PyPI.

Single-line version change. `publish.yml`'s `detect` job will see the new version, kick the test → publish → release chain, and `uv tool upgrade twikit-mcp` will pick up the cards.

## What 0.1.23 includes (since 0.1.22)

| PR | What | User-visible? |
|---|---|---|
| #63 | Twitter-style ASCII cards (`tweet/user/tl/search/trends` in TTY mode) | ✅ Yes |
| #62 | pr-review.yml v2 (Conventional Comments + grounding + self-critique + Sonnet 4.6 ladder) | ❌ No (workflow-only) |
| #64 | CLAUDE.md (repo conventions for Claude Code sessions) | ❌ No (docs-only) |

## Spec / SDD checklist

- [x] No new MCP tool
- [x] No test fixture changes
- [x] No vendor patches
- [x] No live-smoke validators
- [x] Tool count unchanged (still 57)

(Per CLAUDE.md trivial-change carve-out: skipping issue-first since the spec is "version += 1 to ship merged work to PyPI". The diff is one line.)

https://claude.ai/code/session_01YZ5NXtFwvf3yybuRVSzvPY

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZ5NXtFwvf3yybuRVSzvPY)_