### PR TITLE
docs: add 'Monitoring contract' to CLAUDE.md merge policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,33 @@ The instinct to "ask before merging" is wrong here. The maintainer has already
 delegated this decision via #54's pipeline simplification + repeated explicit
 agreement. Asking again per-PR is friction without value.
 
+### Monitoring contract — never break the callback chain
+
+The maintainer's hard rule (PR #66 retro): **the moment you open a PR, the
+event chain is your responsibility — don't let it stall.** If the maintainer
+ever has to type "what's the status?" the chain has broken and you failed.
+
+For every PR you open:
+
+1. **Subscribe** to `mcp__github__subscribe_pr_activity` for review/CI events.
+2. **In parallel**, start a `Bash run_in_background` poll script that:
+   - Polls `https://api.github.com/repos/tangivis/twitter-mcp/commits/<sha>/check-runs`
+     every ~10s.
+   - **Encodes the merge-policy decision in-script**: when all checks complete
+     and substantive ones are green (MiniMax `skipped` is fine for docs-only
+     PRs), the foreground session should auto-merge as soon as the
+     notification arrives — don't wait for a second nudge.
+   - Exits non-zero on red so you fix-and-push without asking.
+3. After merge, start a **second** poll for the cascade run on `main`
+   (publish.yml / docs.yml) so PyPI / Pages confirmation also surfaces
+   automatically.
+
+Webhook alone is not sufficient — events can be batched, dropped, or arrive
+after a long quiet stretch. Background poll is the safety net. Run both.
+
+The cost of "I'll just sit and wait for the webhook" is asking the maintainer
+to be the heartbeat. That's the failure mode this rule prevents.
+
 ---
 
 ## Spec-first workflow


### PR DESCRIPTION
## Summary

PR #66 retro: I broke the autonomy chain by relying solely on webhook subscription, with no background poll as safety net. The maintainer had to type "什么情况" mid-flow — the exact failure mode the merge policy is supposed to prevent.

This PR codifies the rule under `Merge policy` as a new **Monitoring contract** subsection:

- Every PR CC opens: webhook subscription **and** parallel `Bash run_in_background` poll.
- The poll script encodes the merge-policy decision in-line (auto-merge when green, fix-and-push when red).
- After merge: a second poll watches the cascade (`publish.yml` / `docs.yml`) so PyPI / Pages confirmation surfaces without manual prompting.
- Failure-mode test in plain language: if the maintainer ever has to ask "what's the status?", the chain has broken.

## Test plan

- [x] CLAUDE.md renders correctly (markdown linter is the only verification needed).
- [ ] Merge once green; future CC sessions read the new contract on session start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZ5NXtFwvf3yybuRVSzvPY)_