### PR TITLE
ci(claude): pin Sonnet 4.6 + max-turns 15 (cap @claude plan burn)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -66,23 +66,20 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # Optional: Customize the trigger phrase (default: @claude)
-          # trigger_phrase: "/claude"
-
-          # Optional: Trigger when specific user is assigned to an issue
-          # assignee_trigger: "claude-bot"
-
-          # Optional: Configure Claude's behavior with CLI arguments
-          # claude_args: |
-          #   --model claude-opus-4-1-20250805
-          #   --max-turns 10
-          #   --allowedTools "Bash(npm install),Bash(npm run build),Bash(npm run test:*),Bash(npm run lint:*)"
-          #   --system-prompt "Follow our coding standards. Ensure all new code has tests. Use TypeScript for new files."
-
-          # Optional: Advanced settings configuration
-          # settings: |
-          #   {
-          #     "env": {
-          #       "NODE_ENV": "test"
-          #     }
-          #   }
+          # Pin model + turn cap to control plan-quota burn.
+          #
+          # Sonnet 4.6 is plenty for 90% of issue triage / small fixes /
+          # PR feedback in this repo. (Reference: pr-review.yml runs on
+          # MiniMax M2 — strictly weaker — and converges within 5 review
+          # iterations on real PRs.) Opus 4.7 is reserved for cases the
+          # maintainer drives locally via Claude Code; routing the
+          # GitHub bot to Opus on every @claude burns ~5× the tokens
+          # without proportional payoff for this codebase's complexity.
+          #
+          # max-turns 15 caps a runaway loop (each turn = one LLM call
+          # + tool action). 15 covers a typical TDD red→green→PR cycle
+          # with headroom; if the bot can't finish in 15 turns the
+          # task probably needed local Claude Code anyway.
+          claude_args: |
+            --model claude-sonnet-4-6
+            --max-turns 15

--- a/tests/test_claude_trigger_guard.py
+++ b/tests/test_claude_trigger_guard.py
@@ -70,3 +70,29 @@ def test_claude_yml_documents_why_the_guard_exists():
             f"claude.yml lost the {needle!r} mention; the guard "
             f"rationale comment may have been stripped."
         )
+
+
+def test_claude_yml_pins_sonnet_46_model():
+    """The `claude_args` must pin `--model claude-sonnet-4-6` — not let
+    it default to whatever the action picks (which on a Max plan would
+    be Opus 4.7, ~5× the per-token cost without payoff for this repo's
+    complexity). Local Claude Code still picks Opus when the maintainer
+    drives it directly; this rule only governs the GitHub bot."""
+    src = _src()
+    assert "--model claude-sonnet-4-6" in src, (
+        "claude.yml must pin `--model claude-sonnet-4-6` in claude_args. "
+        "Letting the action default to plan-default (Opus on Max) makes "
+        "@claude ~5× more expensive per turn for no measurable benefit "
+        "on this codebase's task complexity."
+    )
+
+
+def test_claude_yml_caps_turn_count():
+    """`--max-turns` must be set so a runaway agent loop doesn't drain
+    plan quota silently."""
+    src = _src()
+    assert re.search(r"--max-turns\s+\d+", src), (
+        "claude.yml must include `--max-turns N` to cap the agent loop. "
+        "Without it a confused agent can rack up 100+ turns chasing a "
+        "phantom error before timing out."
+    )


### PR DESCRIPTION
Follow-up to PR #78 (which locked who can trigger @claude). This PR caps **what model + how many turns** any allowed trigger can spend.

## Pins

```yaml
claude_args: |
  --model claude-sonnet-4-6
  --max-turns 15
```

**Why Sonnet 4.6, not the action default**: Without `--model`, the action picks whatever the OAuth plan defaults to — Opus 4.7 on Max, ~5× the per-token cost. The maintainer's own benchmark for "is this codebase too complex for a smaller model" is `pr-review.yml`, which runs on **MiniMax M2** (strictly weaker than either) and converges within 5 review iterations on real PRs. Sonnet 4.6 is a 2-tier upgrade from MiniMax M2 — comfortably enough headroom for issue triage / small fixes / PR feedback.

**Why max-turns 15**: caps a runaway agent loop. Without it a confused agent can rack up 100+ turns chasing a phantom error before workflow timeout. 15 covers a typical TDD red→green→PR cycle with headroom.

**What this does NOT change**:
- Local Claude Code (the maintainer's own session) still picks Opus when driven directly. This rule only governs the GitHub bot.
- For the rare issue where Sonnet doesn't cut it, the maintainer has the bot's PR + the local Opus session as fallbacks.

## Test plan

Two new sentinels in `tests/test_claude_trigger_guard.py`:
- `test_claude_yml_pins_sonnet_46_model` — asserts `--model claude-sonnet-4-6` is present (regression guard).
- `test_claude_yml_caps_turn_count` — asserts `--max-turns N` is set.

- [x] `pytest tests/test_claude_trigger_guard.py` — **5/5 pass**.
- [x] `pytest -q --cov=twitter_mcp.server --cov-fail-under=95` — **608 pass, 100% coverage**.
- [x] `yaml.safe_load(claude.yml)` parses cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZ5NXtFwvf3yybuRVSzvPY)_