### PR TITLE
feat(get_tweet): expose in_reply_to and conversation_id (closes #77)

### DIFF
--- a/docs/VENDORING.zh.md
+++ b/docs/VENDORING.zh.md
@@ -45,6 +45,7 @@ PyPI 上的 twikit 2.3.3 有两个已知 bug：
 | 0.1.5 | `_vendor/twikit/tweet.py` | `Tweet` 属性全面防御化：`text`/`created_at`/`lang`/`favorite_count`/`retweet_count`/`reply_count`/`favorited`/`is_quote_status` 以及 `entities.*` 子树（hashtags/urls/media）都走 `.get()`。构造时 `_data["legacy"]` 也改为可选。|
 | 0.1.9 | `_vendor/twikit/client/gql.py` | `GQLClient.tweet_result_by_rest_id` 把 `fieldToggles.withArticlePlainText` 从 `False` 翻成 `True`。这是 issue #10 修复 `get_article` 的关键一步：上游默认抑制 article 正文，翻成 `True` 后 `.article.article_results.result.plain_text` 才会真的填充。改动在源文件里加了 `# twitter-mcp patch (issue #10)` 注释,下次 vendor 刷新时不要漏掉。|
 | 0.1.21 | `_vendor/twikit/client/client.py` | `Client.get_lists` 防御化 items[1] 遍历。issue #37 暴露:burner 0 lists 时 X 在 items[1] 塞了 promo 卡片或没有 `itemContent.list` 的 cell,上游用 `list["item"]["itemContent"]["list"]` 直挂 KeyError。改成 `.get()` 链 + 跳过没 list payload 的 entry。打了 `# twitter-mcp patch (issue #37)` 标记 + `tests/test_vendor.py::test_get_lists_skips_non_list_entries` 双重 guard,下次 vendor 刷新别漏。|
+| 0.1.24 | `_vendor/twikit/tweet.py` | 新增 `Tweet.conversation_id` 属性，从 `_legacy["conversation_id_str"]` 读取推文会话根 ID（issue #77）。上游 twikit 未暴露此字段，但 X API legacy 对象始终带有 `conversation_id_str`。用于 `get_tweet` 工具返回 `conversation_id` 和 `in_reply_to` 以支持 agentic 线程回溯。|
 
 ### 为什么要防御化 `User.__init__`
 

--- a/docs/index.en.md
+++ b/docs/index.en.md
@@ -8,12 +8,16 @@
 
 An [MCP](https://modelcontextprotocol.io/) server that lets Claude (or any MCP-compatible AI agent) interact with Twitter/X using browser cookies. The same `twikit-mcp` binary doubles as a CLI for shell scripts and debugging.
 
+## What's new in 0.1.25
+
+- **Conversation context on `get_tweet`** — the response now includes `in_reply_to` (parent tweet ID when the tweet is a reply) and `conversation_id` (root tweet ID of the thread). Agents can now reconstruct thread context from a single tweet without needing the user to paste the parent link. (closes #77)
+
+Upgrade with `uv tool upgrade twikit-mcp` (or `pip install --upgrade twikit-mcp`).
+
 ## What's new in 0.1.24
 
 - **Rich-rendered cards** — the terminal cards from 0.1.23 are now produced by [Rich](https://github.com/Textualize/rich), giving correct cell-width math for emoji + CJK (no more right-border drift on `❤ 🔁` lines), and **OSC 8 clickable hyperlinks** for tweet / profile / bio URLs in iTerm2, kitty, WezTerm, Windows Terminal, gnome-terminal ≥ 3.36, etc. The trends list is now a proper table.
 - Plain (non-TTY) output unchanged: `| jq` / `> file` / `NO_COLOR=1` consumers stay byte-stable.
-
-Upgrade with `uv tool upgrade twikit-mcp` (or `pip install --upgrade twikit-mcp`).
 
 ## What's new in 0.1.23
 

--- a/docs/index.ja.md
+++ b/docs/index.ja.md
@@ -8,12 +8,16 @@
 
 [MCP](https://modelcontextprotocol.io/) サーバー — Claude(や MCP 対応の AI エージェント)がブラウザ cookies で Twitter/X を操作できます。同じ `twikit-mcp` バイナリは CLI としてもシェルスクリプトやデバッグに使えます。
 
+## 0.1.25 の新機能
+
+- **`get_tweet` に会話コンテキストを追加** — レスポンスに `in_reply_to`(リプライ元ツイートID)と `conversation_id`(スレッドのルートツイートID)が含まれるようになりました。エージェントは1つのリプライから親リンクをユーザーに尋ねることなくスレッド全体を遡れます。(closes #77)
+
+アップグレード:`uv tool upgrade twikit-mcp`(または `pip install --upgrade twikit-mcp`)。
+
 ## 0.1.24 の新機能
 
 - **Rich レンダリングのカード** — 0.1.23 のターミナルカードを [Rich](https://github.com/Textualize/rich) が描画するようになりました。emoji と CJK の**列幅計測が正確**(`❤ 🔁` 行で右ボーダーがずれない)、ツイート / プロフィール / bio URL は **OSC 8 でクリッカブル**(iTerm2 / kitty / WezTerm / Windows Terminal / gnome-terminal ≥ 3.36 で cmd-クリックで開きます)。トレンドは真の Table レイアウトに。
 - プレーンテキスト出力(非 TTY)は無変更:`| jq` / `> file` / `NO_COLOR=1` の消費者にとってバイト安定が保たれます。
-
-アップグレード:`uv tool upgrade twikit-mcp`(または `pip install --upgrade twikit-mcp`)。
 
 ## 0.1.23 の新機能
 

--- a/docs/index.zh.md
+++ b/docs/index.zh.md
@@ -8,12 +8,16 @@
 
 [MCP](https://modelcontextprotocol.io/) server,让 Claude(或任何 MCP 兼容的 AI agent)用浏览器 cookies 操作 Twitter/X。同一个 `twikit-mcp` 二进制还能当 CLI 用,适合 shell 脚本和调试。
 
+## 0.1.25 新增
+
+- **`get_tweet` 返回会话上下文** — 响应里现在多了 `in_reply_to`(回复时的父推 ID)和 `conversation_id`(整条 thread 的根推 ID)。Agent 拿到一条回复推文不再需要让用户手动贴父推链接,直接能溯源到根。(closes #77)
+
+升级:`uv tool upgrade twikit-mcp`(或 `pip install --upgrade twikit-mcp`)。
+
 ## 0.1.24 新增
 
 - **Rich 渲染卡片** — 0.1.23 的终端卡片现在改由 [Rich](https://github.com/Textualize/rich) 输出,emoji 和中日韩字符**列宽正确**(`❤ 🔁` 行不再让右边框偏移),并且 tweet / 个人主页 / bio URL 都用 **OSC 8 可点超链接**包裹 — 在 iTerm2 / kitty / WezTerm / Windows Terminal / gnome-terminal ≥ 3.36 里 cmd-click 直接打开。Trends 改成了真正的 Table 排版。
 - 纯文本(非 TTY)输出不变:`| jq` / `> file` / `NO_COLOR=1` 消费者继续字节稳定。
-
-升级:`uv tool upgrade twikit-mcp`(或 `pip install --upgrade twikit-mcp`)。
 
 ## 0.1.23 新增
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "twikit-mcp"
-version = "0.1.24"
+version = "0.1.25"
 description = "Twitter/X MCP server powered by twikit — no API key needed, free forever"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -488,6 +488,8 @@ async def test_tool_output_preserves_unicode_raw(monkeypatch):
         favorite_count=7269,
         retweet_count=5473,
         created_at="Sat Feb 21 16:55:22 +0000 2009",
+        in_reply_to=None,
+        conversation_id=None,
     )
     fake_client = AsyncMock()
     fake_client.get_tweets_by_ids = AsyncMock(return_value=[fake_tweet])

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -27,6 +27,8 @@ def _fake_tweet(
     favorite_count=5,
     retweet_count=2,
     created_at="Mon Jan 01 00:00:00 +0000 2026",
+    in_reply_to=None,
+    conversation_id=None,
 ):
     return SimpleNamespace(
         id=tid,
@@ -35,6 +37,8 @@ def _fake_tweet(
         favorite_count=favorite_count,
         retweet_count=retweet_count,
         created_at=created_at,
+        in_reply_to=in_reply_to,
+        conversation_id=conversation_id,
     )
 
 
@@ -89,7 +93,21 @@ async def test_get_tweet_returns_full_shape(fake_client):
         "created_at": "Sat Apr 18 10:00:00 +0000 2026",
         "likes": 10,
         "retweets": 3,
+        "in_reply_to": None,
+        "conversation_id": None,
     }
+
+
+async def test_get_tweet_includes_reply_context(fake_client):
+    t = _fake_tweet(
+        tid="99999",
+        in_reply_to="88888",
+        conversation_id="77777",
+    )
+    fake_client.get_tweets_by_ids = AsyncMock(return_value=[t])
+    out = json.loads(await server.get_tweet("99999"))
+    assert out["in_reply_to"] == "88888"
+    assert out["conversation_id"] == "77777"
 
 
 @pytest.mark.parametrize(

--- a/twitter_mcp/_vendor/twikit/tweet.py
+++ b/twitter_mcp/_vendor/twikit/tweet.py
@@ -129,6 +129,10 @@ class Tweet:
         return self._legacy.get("in_reply_to_status_id_str")
 
     @property
+    def conversation_id(self) -> str | None:  # twitter-mcp patch (issue #77)
+        return self._legacy.get("conversation_id_str")
+
+    @property
     def is_quote_status(self) -> bool:
         return self._legacy.get("is_quote_status", False)
 

--- a/twitter_mcp/server.py
+++ b/twitter_mcp/server.py
@@ -147,6 +147,8 @@ async def get_tweet(tweet_id: str) -> str:
             "created_at": str(t.created_at),
             "likes": t.favorite_count,
             "retweets": t.retweet_count,
+            "in_reply_to": t.in_reply_to,
+            "conversation_id": t.conversation_id,
         }
     )
 

--- a/uv.lock
+++ b/uv.lock
@@ -1913,7 +1913,7 @@ wheels = [
 
 [[package]]
 name = "twikit-mcp"
-version = "0.1.24"
+version = "0.1.25"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
closes #77

## Summary

Issue #77 surfaced that `get_tweet` doesn't expose conversation context — agentic workflows that receive a single reply tweet have no way to walk back to the parent or root, forcing the user to paste the parent link manually.

Bot draft branch `claude/issue-77-20260506-2253` proposed Solution 1 (add fields to `get_tweet` response). After review I rebased + tightened:

- ✅ The feature itself is **clean and minimal** — `_legacy.get("conversation_id_str")` (defensive `.get()` per the project's vendor-patch convention; marked `# twitter-mcp patch (issue #77)`).
- ⚠️ **Rebased onto current main** — the bot branched before #78 (auth lockdown) + #79 (Sonnet pin) merged, so naive merge would have reverted those security fixes. After rebase, the chain is `feature → #79 → #78 → ...`.
- ⚠️ **Fixed `tests/test_cli.py` SimpleNamespace mirror** — the bot updated `_fake_tweet` factory in `test_tools.py` but missed an inline `SimpleNamespace` in `test_cli.py` (the Greek-tweet UTF-8 regression test). That test was failing AttributeError on the new fields. Now patched.
- ✅ `tests/test_fixture_shapes.py` already enforces `fake ⊆ real`, and the new fields exist on real `Tweet` (`in_reply_to` from upstream, `conversation_id` from this PR's vendor patch), so no fixture-shape changes needed.

## Bumps + ships

- `pyproject.toml`: 0.1.24 → 0.1.25
- `uv.lock`: regenerated
- `docs/index.{en,zh,ja}.md`: "What's new in 0.1.25" added above 0.1.24 (with the upgrade pitch consolidated to the top per existing convention)
- `docs/VENDORING.zh.md`: 1-line entry in the "本地 patch 清单" table for `Tweet.conversation_id`

## Test plan

- [x] `pytest -q --cov=twitter_mcp.server --cov-fail-under=95` — **609 pass, 100% coverage** preserved.
- [x] New regression test `test_get_tweet_includes_reply_context` (mock-based) feeds reply-context into the fake tweet and asserts the fields propagate to JSON output.
- [x] Existing `test_get_tweet_returns_full_shape` updated with the new `None`-defaulting fields.
- [x] `test_claude_trigger_guard.py` (5/5) still green — security work from #78/#79 preserved.
- [x] YAML parses: `claude.yml` / `live-smoke.yml` syntactically clean.
- [ ] Cascade post-merge: `publish.yml` ships 0.1.25 to PyPI; `docs.yml` redeploys Pages.

## Implementation

```diff
+ # twitter_mcp/_vendor/twikit/tweet.py
+ @property
+ def conversation_id(self) -> str | None:  # twitter-mcp patch (issue #77)
+     return self._legacy.get("conversation_id_str")

# twitter_mcp/server.py — get_tweet response
  "retweets": t.retweet_count,
+ "in_reply_to": t.in_reply_to,
+ "conversation_id": t.conversation_id,
```

When the tweet isn't a reply / has no thread, both fields come back as `null` — same shape, no key surprise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZ5NXtFwvf3yybuRVSzvPY)_