### PR TITLE
ci(pr-review): drop draft filter — review every PR event

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -33,7 +33,12 @@ jobs:
     name: MiniMax M2 review
     runs-on: ubuntu-latest
     timeout-minutes: 6
-    if: github.event.pull_request.draft == false
+    # No draft filter — review fires on every PR open / synchronize /
+    # ready_for_review (even when still draft). The maintainer's
+    # workflow opens drafts then auto-merges on green per CLAUDE.md's
+    # Monitoring contract; without this MiniMax review never had time
+    # to run on the maintainer's PRs (skip-on-draft + immediate merge
+    # on ready). Tokens are cheap; review every iteration.
     steps:
       - uses: actions/checkout@v4
         with:

--- a/tests/test_pr_review_v2.py
+++ b/tests/test_pr_review_v2.py
@@ -194,3 +194,18 @@ def test_workflow_keeps_summary_as_top_level_comment():
         "Summary must still post as a top-level PR comment so the "
         "iteration marker + decision are visible at-a-glance."
     )
+
+
+def test_workflow_does_not_skip_drafts():
+    """Reviews run on draft PRs too. The maintainer's workflow opens
+    drafts, polls CI, and auto-merges on green per CLAUDE.md's
+    Monitoring contract — a skip-on-draft filter means MiniMax never
+    actually reviews the maintainer's PRs. Tokens are cheap; review
+    every iteration."""
+    src = _PR_REVIEW.read_text()
+    assert "pull_request.draft == false" not in src, (
+        "pr-review.yml has a `draft == false` filter — that re-introduces "
+        "the gap that PR #82-era retro fixed: maintainer drafts open + "
+        "immediately get merged on green, never giving MiniMax review a "
+        "chance to run. Drop the filter so review fires on every PR event."
+    )


### PR DESCRIPTION
## Problem

The maintainer's Monitoring contract (CLAUDE.md) opens every PR as draft, polls CI to green, marks ready, and immediately merges. With `if: github.event.pull_request.draft == false` on the review job:

- ❌ Skips the initial `opened` event (PR is draft)
- ✅ Re-triggers on `ready_for_review` event when the maintainer marks ready
- ❌ But the auto-merge fires before that second run completes

Net effect: **MiniMax review effectively never runs on the maintainer's PRs**. PR #80 just made this visible — `MiniMax M2 review: skipped` at 0s, immediately followed by the merge before any re-trigger could finish.

The maintainer's call: tokens are cheap, run review on every PR iteration.

## Fix

Drop the `if: draft == false` filter. MiniMax now runs on every PR event (open / synchronize / ready_for_review / reopened) regardless of draft state.

## Test plan

- [x] New sentinel `tests/test_pr_review_v2.py::test_workflow_does_not_skip_drafts` prevents the filter from being silently re-introduced.
- [x] All 24 existing pr-review sentinels still green.
- [x] `pytest -q --cov=twitter_mcp.server --cov-fail-under=95` — **610 pass, 100% coverage**.
- [x] `yaml.safe_load(pr-review.yml)` parses cleanly.
- [ ] Verify post-merge: this very PR's MiniMax review actually completes (it's the first PR after dropping the filter, so it's the proof-test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZ5NXtFwvf3yybuRVSzvPY)_