### PR TITLE
feat(get_tweet): expose quote tweet (is_quote_status + quoted_id/author/text) (closes #82)

### DIFF
--- a/docs/index.en.md
+++ b/docs/index.en.md
@@ -8,11 +8,15 @@
 
 An [MCP](https://modelcontextprotocol.io/) server that lets Claude (or any MCP-compatible AI agent) interact with Twitter/X using browser cookies. The same `twikit-mcp` binary doubles as a CLI for shell scripts and debugging.
 
+## What's new in 0.1.26
+
+- **Quote tweet visibility on `get_tweet`** — the response now includes `is_quote_status`, `quoted_id`, `quoted_author`, and `quoted_text` when the tweet quote-retweets another. Agents can now show the quoted text inline without an extra `get_tweet` round-trip — the data is already in the same GraphQL response, we just expose it. (closes #82)
+
+Upgrade with `uv tool upgrade twikit-mcp` (or `pip install --upgrade twikit-mcp`).
+
 ## What's new in 0.1.25
 
 - **Conversation context on `get_tweet`** — the response now includes `in_reply_to` (parent tweet ID when the tweet is a reply) and `conversation_id` (root tweet ID of the thread). Agents can now reconstruct thread context from a single tweet without needing the user to paste the parent link. (closes #77)
-
-Upgrade with `uv tool upgrade twikit-mcp` (or `pip install --upgrade twikit-mcp`).
 
 ## What's new in 0.1.24
 

--- a/docs/index.ja.md
+++ b/docs/index.ja.md
@@ -8,11 +8,15 @@
 
 [MCP](https://modelcontextprotocol.io/) サーバー — Claude(や MCP 対応の AI エージェント)がブラウザ cookies で Twitter/X を操作できます。同じ `twikit-mcp` バイナリは CLI としてもシェルスクリプトやデバッグに使えます。
 
+## 0.1.26 の新機能
+
+- **`get_tweet` で引用ツイートを公開** — レスポンスに `is_quote_status` / `quoted_id` / `quoted_author` / `quoted_text` が含まれるようになりました。引用リツイートの場合、引用元の作者と本文を即座に確認でき、エージェントが追加で `get_tweet` を呼ぶ必要がありません。これらは元から同じ GraphQL レスポンスに含まれていたものを取り出して公開しただけ。(closes #82)
+
+アップグレード:`uv tool upgrade twikit-mcp`(または `pip install --upgrade twikit-mcp`)。
+
 ## 0.1.25 の新機能
 
 - **`get_tweet` に会話コンテキストを追加** — レスポンスに `in_reply_to`(リプライ元ツイートID)と `conversation_id`(スレッドのルートツイートID)が含まれるようになりました。エージェントは1つのリプライから親リンクをユーザーに尋ねることなくスレッド全体を遡れます。(closes #77)
-
-アップグレード:`uv tool upgrade twikit-mcp`(または `pip install --upgrade twikit-mcp`)。
 
 ## 0.1.24 の新機能
 

--- a/docs/index.zh.md
+++ b/docs/index.zh.md
@@ -8,11 +8,15 @@
 
 [MCP](https://modelcontextprotocol.io/) server,让 Claude(或任何 MCP 兼容的 AI agent)用浏览器 cookies 操作 Twitter/X。同一个 `twikit-mcp` 二进制还能当 CLI 用,适合 shell 脚本和调试。
 
+## 0.1.26 新增
+
+- **`get_tweet` 暴露引用推文** — 响应里现在多了 `is_quote_status`、`quoted_id`、`quoted_author`、`quoted_text`。如果当前推是 quote retweet,直接能看到引用了谁说啥,不用 agent 再 call 一次。这些字段本来就在同一次 GraphQL 响应里,我们只是没抽出来给 agent。(closes #82)
+
+升级:`uv tool upgrade twikit-mcp`(或 `pip install --upgrade twikit-mcp`)。
+
 ## 0.1.25 新增
 
 - **`get_tweet` 返回会话上下文** — 响应里现在多了 `in_reply_to`(回复时的父推 ID)和 `conversation_id`(整条 thread 的根推 ID)。Agent 拿到一条回复推文不再需要让用户手动贴父推链接,直接能溯源到根。(closes #77)
-
-升级:`uv tool upgrade twikit-mcp`(或 `pip install --upgrade twikit-mcp`)。
 
 ## 0.1.24 新增
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "twikit-mcp"
-version = "0.1.25"
+version = "0.1.26"
 description = "Twitter/X MCP server powered by twikit — no API key needed, free forever"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -490,6 +490,8 @@ async def test_tool_output_preserves_unicode_raw(monkeypatch):
         created_at="Sat Feb 21 16:55:22 +0000 2009",
         in_reply_to=None,
         conversation_id=None,
+        is_quote_status=False,
+        quote=None,
     )
     fake_client = AsyncMock()
     fake_client.get_tweets_by_ids = AsyncMock(return_value=[fake_tweet])

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -29,6 +29,8 @@ def _fake_tweet(
     created_at="Mon Jan 01 00:00:00 +0000 2026",
     in_reply_to=None,
     conversation_id=None,
+    is_quote_status=False,
+    quote=None,
 ):
     return SimpleNamespace(
         id=tid,
@@ -39,6 +41,8 @@ def _fake_tweet(
         created_at=created_at,
         in_reply_to=in_reply_to,
         conversation_id=conversation_id,
+        is_quote_status=is_quote_status,
+        quote=quote,
     )
 
 
@@ -95,6 +99,10 @@ async def test_get_tweet_returns_full_shape(fake_client):
         "retweets": 3,
         "in_reply_to": None,
         "conversation_id": None,
+        "is_quote_status": False,
+        "quoted_id": None,
+        "quoted_author": None,
+        "quoted_text": None,
     }
 
 
@@ -108,6 +116,40 @@ async def test_get_tweet_includes_reply_context(fake_client):
     out = json.loads(await server.get_tweet("99999"))
     assert out["in_reply_to"] == "88888"
     assert out["conversation_id"] == "77777"
+
+
+async def test_get_tweet_includes_quote_context(fake_client):
+    """Issue #82: when the tweet is a quote retweet, the response carries
+    the quoted tweet's id / author / text — extracted from the SAME
+    GraphQL response, no extra network call."""
+    quoted = _fake_tweet(
+        tid="20",
+        text="just setting up my twttr",
+        user=_fake_user(screen_name="jack", name="jack"),
+    )
+    quoter = _fake_tweet(
+        tid="55555",
+        text="historic moment",
+        is_quote_status=True,
+        quote=quoted,
+    )
+    fake_client.get_tweets_by_ids = AsyncMock(return_value=[quoter])
+    out = json.loads(await server.get_tweet("55555"))
+    assert out["is_quote_status"] is True
+    assert out["quoted_id"] == "20"
+    assert out["quoted_author"] == "jack"
+    assert out["quoted_text"] == "just setting up my twttr"
+
+
+async def test_get_tweet_quote_fields_default_when_not_quote(fake_client):
+    """Non-quote tweet: all 4 quote keys present with stable defaults
+    (no key-not-present surprises)."""
+    fake_client.get_tweets_by_ids = AsyncMock(return_value=[_fake_tweet(tid="1")])
+    out = json.loads(await server.get_tweet("1"))
+    assert out["is_quote_status"] is False
+    assert out["quoted_id"] is None
+    assert out["quoted_author"] is None
+    assert out["quoted_text"] is None
 
 
 @pytest.mark.parametrize(

--- a/twitter_mcp/server.py
+++ b/twitter_mcp/server.py
@@ -138,6 +138,7 @@ async def get_tweet(tweet_id: str) -> str:
             f"use get_article instead."
         )
     t = tweets[0]
+    q = t.quote  # Tweet | None — sync, uses already-fetched response (issue #82)
     return _dumps(
         {
             "id": t.id,
@@ -149,6 +150,10 @@ async def get_tweet(tweet_id: str) -> str:
             "retweets": t.retweet_count,
             "in_reply_to": t.in_reply_to,
             "conversation_id": t.conversation_id,
+            "is_quote_status": t.is_quote_status,
+            "quoted_id": q.id if q else None,
+            "quoted_author": q.user.screen_name if q else None,
+            "quoted_text": q.text if q else None,
         }
     )
 

--- a/uv.lock
+++ b/uv.lock
@@ -1913,7 +1913,7 @@ wheels = [
 
 [[package]]
 name = "twikit-mcp"
-version = "0.1.25"
+version = "0.1.26"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
closes #82

## Summary

Follow-up to #77. When a tweet is a **quote retweet**, the response now exposes the quoted tweet inline:

```diff
{
  "id": "55555",
  "text": "historic moment",
+ "is_quote_status": true,
+ "quoted_id": "20",
+ "quoted_author": "jack",
+ "quoted_text": "just setting up my twttr",
  ...
}
```

**Zero extra network**. `Tweet.quote` (line 211 of `_vendor/twikit/tweet.py`) is sync and rebuilds from the **same GraphQL response's** `quoted_status_result` payload — agents see the quoted text in the first call without a follow-up `get_tweet`.

When the tweet is NOT a quote, all 4 keys appear with stable defaults (`false` / `null` / `null` / `null`) — no key-not-present surprises.

## TDD

Red → green:

1. `_fake_tweet` factory grows `is_quote_status` + `quote` params (mirrors Tweet model's accessor shape; `test_fixture_shapes` stays green since `factory ⊆ real` holds).
2. `test_get_tweet_returns_full_shape` updated with the 4 new keys.
3. New `test_get_tweet_includes_quote_context` — feeds nested quote, asserts all 4 fields propagate.
4. New `test_get_tweet_quote_fields_default_when_not_quote` — non-quote tweet still has the 4 keys with stable defaults.
5. `test_cli.py` SimpleNamespace fake updated (mirroring drift would `AttributeError` on `t.quote` — same drill as #80).

## Test plan

- [x] `pytest tests/test_tools.py -k "get_tweet"` — **8/8 pass**.
- [x] `pytest -q --cov=twitter_mcp.server --cov-fail-under=95` — **612 pass, 100% coverage**.
- [x] `_fake_tweet` ⊆ real Tweet (test_fixture_shapes still green).
- [x] All 24 pr-review sentinels still green; 5/5 trigger-guard sentinels still green.
- [x] `pyproject.toml` bumped 0.1.25 → 0.1.26; `uv.lock` regenerated.
- [x] Tri-lingual landing pages updated with "What's new in 0.1.26".

## Out of scope

- **Recursive quote expansion** — `quoted_text` is 1 level only. If A quotes B which quotes C, only A's response shows B's text. Bounded JSON size.
- **Retweet target** (`Tweet.retweeted_tweet`) — separate concept; pure RTs out of scope here.
- **Card UI** — human-friendly `twikit-mcp tweet` rendering of quoted text inside the card is a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZ5NXtFwvf3yybuRVSzvPY)_