### PR TITLE
ci(live-smoke): tolerate `Invalid list id` on list-tweets (X-gating)

### DIFF
--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -341,7 +341,13 @@ jobs:
           # get_list_tweets are now defensively parsed (issue #76 list patch
           # in 0.1.28). If `IndexError` / `KeyError 'created_at'` reappears
           # on a list tool, that's a real regression we want to see.
-          T_LIST = ("List not found", "not found")
+          #
+          # `Invalid list id` IS retained as X-gating tolerance (not a
+          # parser bug): twikit raises this when the response has no
+          # `entries` key at all — i.e. X completely gated the list
+          # timeline for the burner. Same class as `User not found` on
+          # follower lists (#37).
+          T_LIST = ("List not found", "not found", "Invalid list id")
           T_COMM = ("Community not found", "not found", "not authorized") + T_DRIFT
           T_DM = ("Cannot send messages", "User not found", "no DM")
           T_SEARCH = T_DRIFT  # community/user search hits the same parser


### PR DESCRIPTION
## Hotfix for PR #86 cascade red

Live-smoke on `53483b2` (PR #86 merge) failed:

```
✗ get_list_tweets: ValueError: Invalid list id: 1093659386737872897
```

PR #86 dropped `T_DRIFT` from `T_LIST` since the `IndexError` / `KeyError 'created_at'` parser bugs are now actually fixed. But it **also** dropped `"Invalid list id"` — and that turned out to be wrong.

## Why `Invalid list id` is X-gating, not parser drift

Looking at `Client.get_list_tweets`:

```python
items_ = find_dict(response, "entries", find_one=True)
if not items_:
    raise ValueError(f"Invalid list id: {list_id}")
items = items_[0]
```

PR #86's defensive parse handles `items=[]` (entries present but empty). It does **not** silence the `Invalid list id` ValueError that fires when `find_dict` returns `[]` — i.e. the response has **no `entries` key at all**.

That's the case live-smoke just hit. X completely gated the list timeline for the burner (X tightens visibility on low-trust accounts; `1093659386737872897` is a public list, but that doesn't mean burners can iterate its tweets). This is the same class as `User not found` on follower lists from issue #37 — **path (b) X-gating**, not path (c) parser drift.

## Fix

Add `"Invalid list id"` back to `T_LIST` as a documented X-gating tolerance, kept distinct from `T_DRIFT`:

```diff
-T_LIST = ("List not found", "not found")
+T_LIST = ("List not found", "not found", "Invalid list id")
```

Comment in the workflow distinguishes the two error classes so a future maintainer doesn't re-conflate them.

## Test plan

- [x] `pytest -q --cov=twitter_mcp.server --cov-fail-under=95` — 653 pass, 100% coverage (no Python changes; sanity check).
- [x] `yaml.safe_load(.github/workflows/live-smoke.yml)` parses cleanly.
- [ ] Cascade post-merge: live-smoke 25 reads land green/tolerated again, with `get_list_tweets` showing `✓ tolerated (...)` instead of `✗`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZ5NXtFwvf3yybuRVSzvPY)_