### PR TITLE
hotfix(community): correct live-smoke validators + Client.get_community guard

### DIFF
--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -293,24 +293,27 @@ jobs:
               return f"{len(o['communities'])} community hits (empty OK — X gates)"
 
           def v_search_community_tweet(o):
-              assert isinstance(o, list), "not a list"
-              return f"{len(o)} community-tweet hits (empty OK — X gates)"
+              assert isinstance(o.get("tweets"), list), "missing 'tweets' key"
+              return f"{len(o['tweets'])} community-tweet hits (empty OK — X gates)"
 
           def v_communities_timeline(o):
               assert isinstance(o.get("tweets"), list), "missing 'tweets' key"
               return f"{len(o['tweets'])} community-timeline tweets (empty OK)"
 
           def v_community_tweets(o):
-              assert isinstance(o, list), "not a list"
-              return f"{len(o)} community tweets (empty OK)"
+              assert isinstance(o.get("tweets"), list), "missing 'tweets' key"
+              return f"{len(o['tweets'])} community tweets (empty OK)"
 
           def v_community_members(o):
-              assert isinstance(o.get("users"), list), "missing 'users' key"
-              return f"{len(o['users'])} community members (empty OK)"
+              # server.py wraps as {"members": [...]}, not "users"
+              assert isinstance(o.get("members"), list), "missing 'members' key"
+              return f"{len(o['members'])} community members (empty OK)"
 
           def v_community_moderators(o):
-              assert isinstance(o.get("users"), list), "missing 'users' key"
-              return f"{len(o['users'])} community moderators (empty OK)"
+              assert isinstance(o.get("moderators"), list), (
+                  "missing 'moderators' key"
+              )
+              return f"{len(o['moderators'])} community moderators (empty OK)"
 
           def v_search_user(o):
               assert isinstance(o.get("users"), list), "missing 'users' key"

--- a/tests/test_community_parsing.py
+++ b/tests/test_community_parsing.py
@@ -311,3 +311,39 @@ async def test_search_community_tweet_returns_empty_when_entries_empty():
         client, "C", "ai", count=5, cursor=None
     )
     assert list(result) == []
+
+
+# ── get_community: missing-result / no-rest_id paths ─────
+
+
+async def test_get_community_raises_not_found_when_no_result():
+    """find_dict returns [] (X gates burner entirely) → NotFound, not
+    IndexError. PR #88 hotfix follow-up."""
+    from twitter_mcp._vendor.twikit.errors import NotFound
+
+    client = object.__new__(Client)
+
+    async def fake_community_query(community_id):
+        return {"data": {}}, None
+
+    client.gql = type("FakeGQL", (), {})()
+    client.gql.community_query = fake_community_query
+    with pytest.raises(NotFound, match="not found"):
+        await Client.get_community(client, "C")
+
+
+async def test_get_community_raises_not_found_when_result_missing_rest_id():
+    """find_dict returns a dict without `rest_id` (X truncated shape) →
+    NotFound, not KeyError on Community.__init__."""
+    from twitter_mcp._vendor.twikit.errors import NotFound
+
+    client = object.__new__(Client)
+
+    async def fake_community_query(community_id):
+        # Has `result` key but not `rest_id` inside it.
+        return {"data": {"communityResults": {"result": {"some_other": "x"}}}}, None
+
+    client.gql = type("FakeGQL", (), {})()
+    client.gql.community_query = fake_community_query
+    with pytest.raises(NotFound, match="not found"):
+        await Client.get_community(client, "C")

--- a/twitter_mcp/_vendor/twikit/client/client.py
+++ b/twitter_mcp/_vendor/twikit/client/client.py
@@ -3941,8 +3941,16 @@ class Client:
             Community object.
         """
         response, _ = await self.gql.community_query(community_id)
-        community_data = find_dict(response, "result", find_one=True)[0]
-        return Community(self, community_data)
+        # Defensive: when X gates the burner, `find_dict` may return []
+        # (no `result`) or return a result dict without `rest_id`
+        # (truncated / error shape). Both used to raise IndexError or
+        # KeyError; surface as `Community not found` instead — live-smoke
+        # already tolerates that string under T_COMM.
+        # twitter-mcp patch (issue #76)
+        results = find_dict(response, "result", find_one=True)
+        if not results or "rest_id" not in (results[0] or {}):
+            raise NotFound(f"Community {community_id} not found.")
+        return Community(self, results[0])
 
     async def get_community_tweets(
         self,


### PR DESCRIPTION
## Hotfix for PR #88 cascade red

Live-smoke on `0209c40` (PR #88 merge) failed with 5 community-tool errors:

```
✗ get_community: KeyError: 'rest_id'
✗ search_community_tweet: assertion failed — not a list
✗ get_community_tweets: assertion failed — not a list
✗ get_community_members: assertion failed — missing 'users' key
✗ get_community_moderators: assertion failed — missing 'users' key
```

Two distinct bug classes:

### 1. Wrong validator shapes (4 of 5)

I made the **same mistake** as in the original 25-read extension (PR #75 → fixed in PR #75 follow-up): assumed wrong response shape. Server wraps everything as a dict:

| Tool | Server returns | Old validator expected | Fixed |
|---|---|---|---|
| `get_community_tweets` | `{"tweets": [...]}` | `list` | `o.get("tweets")` |
| `search_community_tweet` | `{"tweets": [...]}` | `list` | `o.get("tweets")` |
| `get_community_members` | `{"members": [...]}` | `o.get("users")` | `o.get("members")` |
| `get_community_moderators` | `{"moderators": [...]}` | `o.get("users")` | `o.get("moderators")` |

### 2. `Client.get_community` strict accesses (1 of 5)

`find_dict(response, "result", find_one=True)[0]` indexes `[0]` on a possibly-empty list → `IndexError`. Even when `find_dict` finds something, the result dict may not have `rest_id` (X truncated shape) → `KeyError` on `Community.__init__`.

PR #88's defensive parse only fixed the LATER stages (timeline / users helpers); `get_community` itself still had the bug.

**Fix**: guard both at the Client level — raise `NotFound("Community not found.")` for either failure mode. `server.py` already catches `NotFound → ToolError`, and `T_COMM` already tolerates `"Community not found"` / `"not found"`.

## Test plan

- [x] **2 new regression tests** in `tests/test_community_parsing.py`:
  - `test_get_community_raises_not_found_when_no_result` (find_dict empty)
  - `test_get_community_raises_not_found_when_result_missing_rest_id`
- [x] `pytest -q --cov=twitter_mcp.server --cov-fail-under=95` — **686 pass, 100% coverage**.
- [x] `yaml.safe_load(.github/workflows/live-smoke.yml)` parses cleanly.
- [ ] Cascade post-merge: live-smoke 25 reads finally green/tolerated end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZ5NXtFwvf3yybuRVSzvPY)_