### PR TITLE
docs(api): localize /zh/api/ + /ja/api/ chrome (closes #90)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,5 @@ cookies.json
 # MkDocs build output
 /site/
 /docs/api.md
+/docs/api.*.md
 /docs/_cli_tools.*.md

--- a/docs/index.en.md
+++ b/docs/index.en.md
@@ -8,11 +8,15 @@
 
 An [MCP](https://modelcontextprotocol.io/) server that lets Claude (or any MCP-compatible AI agent) interact with Twitter/X using browser cookies. The same `twikit-mcp` binary doubles as a CLI for shell scripts and debugging.
 
+## What's new in 0.1.30
+
+- **Localized API docs page** — `/zh/api/` and `/ja/api/` now show Chinese / Japanese chrome (title, intro, table headers, section labels) instead of falling back to English. Tool docstrings stay native (Python source) — same trade-off `mkdocstrings` makes. (closes #90)
+
+Upgrade with `uv tool upgrade twikit-mcp` (or `pip install --upgrade twikit-mcp`).
+
 ## What's new in 0.1.29
 
 - **Community + article-preview reliability** — `get_community` / `get_community_tweets` / `get_community_members` / `get_community_moderators` / `search_community_tweet` no longer crash with `KeyError: 'rest_id'` / `IndexError`. `get_article_preview` now surfaces a clean `ToolError` instead of leaking `HTTPStatusError` when the syndication endpoint returns 404 for a stale article. Defensive `.get()` parsing in `_vendor/twikit/community.py` + `client.py`. Closes issue #76 — `T_DRIFT` is now empty in `live-smoke.yml`. (issue #76 parts 2 + 3)
-
-Upgrade with `uv tool upgrade twikit-mcp` (or `pip install --upgrade twikit-mcp`).
 
 ## What's new in 0.1.28
 

--- a/docs/index.ja.md
+++ b/docs/index.ja.md
@@ -8,11 +8,15 @@
 
 [MCP](https://modelcontextprotocol.io/) サーバー — Claude(や MCP 対応の AI エージェント)がブラウザ cookies で Twitter/X を操作できます。同じ `twikit-mcp` バイナリは CLI としてもシェルスクリプトやデバッグに使えます。
 
+## 0.1.30 の新機能
+
+- **API ドキュメントページのローカライズ** — `/zh/api/` と `/ja/api/` で中国語 / 日本語の chrome(タイトル、イントロ、テーブルヘッダ、セクション名)を表示するようになりました。英語へフォールバックしません。ツールの docstring は Python ソースのまま(`mkdocstrings` と同じトレードオフ)。(closes #90)
+
+アップグレード:`uv tool upgrade twikit-mcp`(または `pip install --upgrade twikit-mcp`)。
+
 ## 0.1.29 の新機能
 
 - **Community と article-preview の信頼性向上** — `get_community` / `get_community_tweets` / `get_community_members` / `get_community_moderators` / `search_community_tweet` が `KeyError: 'rest_id'` / `IndexError` でクラッシュしなくなりました。`get_article_preview` は syndication エンドポイントが 404(X が古い記事を削除)を返した場合、`HTTPStatusError` のスタックトレースを漏らさずクリーンな `ToolError` を返します。`_vendor/twikit/community.py` + `client.py` の全面 `.get()` 防御化。**Issue #76 完了** — `T_DRIFT` は空集合になりました。(issue #76 parts 2 + 3)
-
-アップグレード:`uv tool upgrade twikit-mcp`(または `pip install --upgrade twikit-mcp`)。
 
 ## 0.1.28 の新機能
 

--- a/docs/index.zh.md
+++ b/docs/index.zh.md
@@ -8,11 +8,15 @@
 
 [MCP](https://modelcontextprotocol.io/) server,让 Claude(或任何 MCP 兼容的 AI agent)用浏览器 cookies 操作 Twitter/X。同一个 `twikit-mcp` 二进制还能当 CLI 用,适合 shell 脚本和调试。
 
+## 0.1.30 新增
+
+- **API 文档页面本地化** — `/zh/api/` 和 `/ja/api/` 现在显示中文 / 日文 chrome(标题、引言、表头、节标题),不再 fallback 到英文。工具 docstring 保持原文(从 Python 源码读),与 `mkdocstrings` 同套权衡。(closes #90)
+
+升级:`uv tool upgrade twikit-mcp`(或 `pip install --upgrade twikit-mcp`)。
+
 ## 0.1.29 新增
 
 - **Community + article-preview 稳定性** — `get_community` / `get_community_tweets` / `get_community_members` / `get_community_moderators` / `search_community_tweet` 不再因 `KeyError: 'rest_id'` 或 `IndexError` 崩。`get_article_preview` 在 syndication 端点 404(X 删了旧文章)时返回干净的 `ToolError`,不再泄露 `HTTPStatusError` 堆栈。`_vendor/twikit/community.py` + `client.py` 全面 `.get()` 防御化。**Issue #76 全部完成** — `T_DRIFT` 现在是空集了。(issue #76 parts 2 + 3)
-
-升级:`uv tool upgrade twikit-mcp`(或 `pip install --upgrade twikit-mcp`)。
 
 ## 0.1.28 新增
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "twikit-mcp"
-version = "0.1.29"
+version = "0.1.30"
 description = "Twitter/X MCP server powered by twikit — no API key needed, free forever"
 readme = "README.md"
 license = "MIT"

--- a/scripts/gen_api_docs.py
+++ b/scripts/gen_api_docs.py
@@ -1,8 +1,13 @@
-"""Generate docs/api.md from `mcp._tool_manager._tools`.
+"""Generate `docs/api.{en,zh,ja}.md` from `mcp._tool_manager._tools`.
 
 Run this script BEFORE `mkdocs build` (the docs.yml CI workflow does
-this automatically). The output `docs/api.md` is gitignored — generated
-fresh on every build, so it can never drift from the live tool registry.
+this automatically). The outputs are gitignored — generated fresh on
+every build, so they can never drift from the live tool registry.
+
+Per-locale chrome (title / intro / table / section headers) is
+translated via `_LOCALES`; tool docstrings stay native (Python source).
+mkdocs-static-i18n serves the locale-appropriate file at
+/<locale>/api/ (issue #90).
 
 Why a standalone script + gitignore instead of `mkdocs-gen-files`:
 the i18n plugin (`mkdocs-static-i18n`) doesn't reliably pick up virtual
@@ -262,17 +267,16 @@ _LOCALES = {
 }
 
 
-def _write_api_page() -> None:
-    """Emit a single English `docs/api.md`.
+def _write_api_page(locale: str) -> None:
+    """Emit `docs/api.<locale>.md` with localized chrome.
 
-    The api page content is Python signatures + types + CLI examples —
-    language-neutral, so localizing it would create maintenance churn
-    without meaningful UX gain. Readers in zh/ja locale see this page
-    in English (acceptable tradeoff for API ref since types and arg
-    names are English regardless).
+    Tool docstrings stay native (Python source) — translating 57
+    docstrings would create maintenance drift. Title / intro / table /
+    section headers are translated per `_LOCALES[locale]`. mkdocs-static-i18n
+    serves the locale-appropriate file at /<locale>/api/.
     """
-    L = _LOCALES["en"]
-    out_path = _REPO_ROOT / "docs" / "api.md"
+    L = _LOCALES[locale]
+    out_path = _REPO_ROOT / "docs" / f"api.{locale}.md"
     with out_path.open("w", encoding="utf-8") as f:
         f.write(f"# {L['title']}\n\n")
         f.write(L["intro"])
@@ -416,6 +420,11 @@ def _write_cli_tools_page(locale: str) -> None:
 
 for _loc in ("en", "zh", "ja"):
     _write_cli_tools_page(_loc)
+    _write_api_page(_loc)
 
 
-_write_api_page()
+# Clean up the legacy single-file `api.md` if a previous build left
+# one — mkdocs-static-i18n now serves `api.{en,zh,ja}.md` per locale.
+_legacy = _REPO_ROOT / "docs" / "api.md"
+if _legacy.exists():
+    _legacy.unlink()

--- a/tests/test_docs_api_listing.py
+++ b/tests/test_docs_api_listing.py
@@ -28,12 +28,14 @@ _LOCALE_TITLES = {
 @pytest.fixture(scope="module", autouse=True)
 def _regen_docs():
     """Run the generator once per module so tests see fresh files.
-    The script is mock-free (reads `mcp._tool_manager._tools`) and idempotent.
-    """
+    The script is mock-free (reads `mcp._tool_manager._tools`) and
+    idempotent. Use `sys.executable` so Windows runners (where
+    `python` may not be on PATH the same way) work the same."""
     import subprocess
+    import sys
 
     subprocess.run(
-        ["python", str(_REPO_ROOT / "scripts" / "gen_api_docs.py")],
+        [sys.executable, str(_REPO_ROOT / "scripts" / "gen_api_docs.py")],
         check=True,
         cwd=_REPO_ROOT,
     )

--- a/tests/test_docs_api_listing.py
+++ b/tests/test_docs_api_listing.py
@@ -1,0 +1,93 @@
+"""Issue #90: API docs page must be localized per locale.
+
+Sentinel: run `scripts/gen_api_docs.py` (idempotent, mock-free) and
+assert that `docs/api.{en,zh,ja}.md` exist with locale-appropriate
+chrome (title) and tool-name parity (every registered MCP tool
+appears in every locale page).
+
+Pattern matches `tests/test_docs_cli_listing.py`.
+"""
+
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_API_FILES = {
+    "en": _REPO_ROOT / "docs" / "api.en.md",
+    "zh": _REPO_ROOT / "docs" / "api.zh.md",
+    "ja": _REPO_ROOT / "docs" / "api.ja.md",
+}
+_LOCALE_TITLES = {
+    "en": "MCP Tools API Reference",
+    "zh": "MCP 工具 API 参考",
+    "ja": "MCP ツール API リファレンス",
+}
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _regen_docs():
+    """Run the generator once per module so tests see fresh files.
+    The script is mock-free (reads `mcp._tool_manager._tools`) and idempotent.
+    """
+    import subprocess
+
+    subprocess.run(
+        ["python", str(_REPO_ROOT / "scripts" / "gen_api_docs.py")],
+        check=True,
+        cwd=_REPO_ROOT,
+    )
+
+
+@pytest.mark.parametrize("locale", ["en", "zh", "ja"])
+def test_api_page_exists_per_locale(locale):
+    """Every locale gets a `docs/api.<locale>.md`."""
+    assert _API_FILES[locale].exists(), (
+        f"docs/api.{locale}.md missing — gen_api_docs.py didn't emit it. "
+        f"Issue #90: api docs must be localized."
+    )
+
+
+@pytest.mark.parametrize("locale", ["en", "zh", "ja"])
+def test_api_page_title_is_localized(locale):
+    """Title (first `# ` line) is in the right language."""
+    src = _API_FILES[locale].read_text(encoding="utf-8")
+    expected_title = _LOCALE_TITLES[locale]
+    assert f"# {expected_title}" in src, (
+        f"docs/api.{locale}.md doesn't start with '# {expected_title}'. "
+        f"Either the chrome translation drifted or i18n broke."
+    )
+
+
+def test_api_pages_have_tool_name_parity():
+    """Every registered MCP tool appears in all 3 locale pages — i.e. the
+    locales differ only in chrome, never in which tools they document."""
+    from twitter_mcp.server import mcp
+
+    tool_names = set(mcp._tool_manager._tools.keys())
+    pages = {
+        locale: path.read_text(encoding="utf-8") for locale, path in _API_FILES.items()
+    }
+
+    missing_per_locale = {}
+    for locale, src in pages.items():
+        # Tool names appear as `### \`<name>\`` headers in the generated md.
+        missing = [n for n in tool_names if f"`{n}`" not in src]
+        if missing:
+            missing_per_locale[locale] = missing
+    assert not missing_per_locale, (
+        f"Tool-name parity broken across locales: {missing_per_locale}. "
+        f"Every locale must list every tool — chrome-only translation, "
+        f"docstrings stay native."
+    )
+
+
+def test_legacy_api_md_is_not_emitted():
+    """The pre-issue-#90 `docs/api.md` (single English file) is no
+    longer the source of truth — i18n now uses `api.<locale>.md`. Make
+    sure the generator cleaned up any leftover."""
+    legacy = _REPO_ROOT / "docs" / "api.md"
+    assert not legacy.exists(), (
+        f"Legacy {legacy} found. The generator should unlink it after "
+        f"writing the per-locale files (issue #90)."
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -1913,7 +1913,7 @@ wheels = [
 
 [[package]]
 name = "twikit-mcp"
-version = "0.1.29"
+version = "0.1.30"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
closes #90

## Problem

User flagged `/ja/api/` (and `/zh/api/`) showed **English chrome**:
- Title: "MCP Tools API Reference"
- Intro: "Auto-generated from the @mcp.tool()…"
- Table headers: "Form / When to use"
- Section labels: "Tweets" / "Users" / "Lists" / "Communities" / …

`scripts/gen_api_docs.py` wrote a single English `docs/api.md`; mkdocs-static-i18n had no locale-specific overrides so EN served all 3 locales.

## Fix

Refactor `_write_api_page()` to take `locale` parameter and emit `docs/api.{en,zh,ja}.md` per locale — same pattern as the existing `_cli_tools.{en,zh,ja}.md` generation (issue #58 / PR #59). The `_LOCALES` dict in `gen_api_docs.py` already had ZH/JA chrome translations prepared but never wired up; this PR plugs them in.

**Tool docstrings stay native** (Python source) — same trade-off `mkdocstrings` makes. Translating 57 docstrings would triple maintenance and decouple doc text from code.

Cleanup: legacy `docs/api.md` is unlinked at end of generator. `.gitignore` extended to `api.*.md` glob.

## Test plan

- [x] **8 new tests** in `tests/test_docs_api_listing.py`:
  - 3× `test_api_page_exists_per_locale` (parametrized en/zh/ja)
  - 3× `test_api_page_title_is_localized` (parametrized — checks first `# ` line)
  - `test_api_pages_have_tool_name_parity` — every registered MCP tool appears in every locale page (chrome differs, content doesn't)
  - `test_legacy_api_md_is_not_emitted` — generator cleans up old single-file
- [x] `pytest -q --cov=twitter_mcp.server --cov-fail-under=95` — **694 pass, 100% coverage**.
- [x] `mkdocs build` — i18n suffix mode correctly maps nav `api.md` → `api.<locale>.md` per locale (verified via `INFO mkdocs_static_i18n: Overriding 'zh' config 'nav' with [...{'MCP 工具 API': 'api.md'}...]`).
- [x] First lines verified — `# MCP Tools API Reference` / `# MCP 工具 API 参考` / `# MCP ツール API リファレンス`.
- [ ] Cascade post-merge: docs.yml redeploys, https://tangivis.github.io/twitter-mcp/ja/api/ shows Japanese chrome.

## Out of scope

- Translating tool docstrings — stay native per `mkdocstrings` convention.
- TECHNICAL.md / VENDORING.md localization — those already opt-in to ZH-only with EN/JA stubs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZ5NXtFwvf3yybuRVSzvPY)_