### PR TITLE
docs: per-client install matrix — Cursor / Claude Desktop / Windsurf / Cline / opencode (closes #92)

### DIFF
--- a/docs/index.en.md
+++ b/docs/index.en.md
@@ -8,11 +8,15 @@
 
 An [MCP](https://modelcontextprotocol.io/) server that lets Claude (or any MCP-compatible AI agent) interact with Twitter/X using browser cookies. The same `twikit-mcp` binary doubles as a CLI for shell scripts and debugging.
 
+## What's new in 0.1.31
+
+- **Per-client install matrix in docs** — new [Install page](install.md) walks through registering `twikit-mcp` with Claude Code / Claude Desktop / Cursor / Windsurf / Cline / opencode (config file path + JSON snippet, ≤ 12 lines per client). Single canonical install command (`uv tool install twikit-mcp`); JSON shape is universal across clients. (closes #92)
+
+Upgrade with `uv tool upgrade twikit-mcp` (or `pip install --upgrade twikit-mcp`).
+
 ## What's new in 0.1.30
 
 - **Localized API docs page** — `/zh/api/` and `/ja/api/` now show Chinese / Japanese chrome (title, intro, table headers, section labels) instead of falling back to English. Tool docstrings stay native (Python source) — same trade-off `mkdocstrings` makes. (closes #90)
-
-Upgrade with `uv tool upgrade twikit-mcp` (or `pip install --upgrade twikit-mcp`).
 
 ## What's new in 0.1.29
 

--- a/docs/index.ja.md
+++ b/docs/index.ja.md
@@ -8,11 +8,15 @@
 
 [MCP](https://modelcontextprotocol.io/) サーバー — Claude(や MCP 対応の AI エージェント)がブラウザ cookies で Twitter/X を操作できます。同じ `twikit-mcp` バイナリは CLI としてもシェルスクリプトやデバッグに使えます。
 
+## 0.1.31 の新機能
+
+- **クライアント別インストール手順を文書化** — 新規[インストールページ](install.md)で Claude Code / Claude Desktop / Cursor / Windsurf / Cline / opencode 6 クライアントへの登録手順を整理(クライアントあたり ≤ 12 行、設定ファイルパス + JSON スニペットのみ)。インストールコマンドは `uv tool install twikit-mcp` 統一、JSON の形はどのクライアントでも共通。(closes #92)
+
+アップグレード:`uv tool upgrade twikit-mcp`(または `pip install --upgrade twikit-mcp`)。
+
 ## 0.1.30 の新機能
 
 - **API ドキュメントページのローカライズ** — `/zh/api/` と `/ja/api/` で中国語 / 日本語の chrome(タイトル、イントロ、テーブルヘッダ、セクション名)を表示するようになりました。英語へフォールバックしません。ツールの docstring は Python ソースのまま(`mkdocstrings` と同じトレードオフ)。(closes #90)
-
-アップグレード:`uv tool upgrade twikit-mcp`(または `pip install --upgrade twikit-mcp`)。
 
 ## 0.1.29 の新機能
 

--- a/docs/index.zh.md
+++ b/docs/index.zh.md
@@ -8,11 +8,15 @@
 
 [MCP](https://modelcontextprotocol.io/) server,让 Claude(或任何 MCP 兼容的 AI agent)用浏览器 cookies 操作 Twitter/X。同一个 `twikit-mcp` 二进制还能当 CLI 用,适合 shell 脚本和调试。
 
+## 0.1.31 新增
+
+- **各客户端安装矩阵文档** — 新增[安装页](install.md),走过 Claude Code / Claude Desktop / Cursor / Windsurf / Cline / opencode 6 个客户端的注册步骤(每个 ≤ 12 行,只列配置文件路径 + JSON 片段)。统一安装命令(`uv tool install twikit-mcp`),JSON 形状跨客户端通用。(closes #92)
+
+升级:`uv tool upgrade twikit-mcp`(或 `pip install --upgrade twikit-mcp`)。
+
 ## 0.1.30 新增
 
 - **API 文档页面本地化** — `/zh/api/` 和 `/ja/api/` 现在显示中文 / 日文 chrome(标题、引言、表头、节标题),不再 fallback 到英文。工具 docstring 保持原文(从 Python 源码读),与 `mkdocstrings` 同套权衡。(closes #90)
-
-升级:`uv tool upgrade twikit-mcp`(或 `pip install --upgrade twikit-mcp`)。
 
 ## 0.1.29 新增
 

--- a/docs/install.en.md
+++ b/docs/install.en.md
@@ -1,0 +1,171 @@
+# Install + register with your MCP client
+
+Three steps. Pick your client at step 3.
+
+## 1. Install the binary
+
+```bash
+uv tool install twikit-mcp
+```
+
+Why `uv tool install`: drops `twikit-mcp` on your `PATH` in an isolated env (no dependency conflicts), instant subsequent startups, single command to upgrade later (`uv tool upgrade twikit-mcp`).
+
+If you don't have `uv`: [install it](https://docs.astral.sh/uv/getting-started/installation/) (one curl line on macOS / Linux). Or use `pipx` / `pip` — see the [README "Choose your install"](https://github.com/tangivis/twitter-mcp#choose-your-install) for those alternatives.
+
+## 2. Drop your X cookies
+
+Log into [x.com](https://x.com) in a browser → DevTools (F12) → **Application** → **Cookies** → `https://x.com`. Copy `ct0` and `auth_token`.
+
+```bash
+mkdir -p ~/.config/twitter-mcp
+cat > ~/.config/twitter-mcp/cookies.json <<'EOF'
+{"ct0": "...", "auth_token": "..."}
+EOF
+chmod 600 ~/.config/twitter-mcp/cookies.json
+```
+
+## 3. Register with your client
+
+Same JSON shape (`mcpServers` block) for every client; only the **config file location** differs. Replace `/home/YOU` with your actual home path.
+
+### Claude Code
+
+CLI command — no JSON editing:
+
+```bash
+claude mcp add twitter -s user \
+  -e "TWITTER_COOKIES=$HOME/.config/twitter-mcp/cookies.json" \
+  -- twikit-mcp
+```
+
+### Claude Desktop
+
+| OS | Config file |
+|---|---|
+| macOS | `~/Library/Application Support/Claude/claude_desktop_config.json` |
+| Windows | `%APPDATA%\Claude\claude_desktop_config.json` |
+| Linux | `~/.config/Claude/claude_desktop_config.json` |
+
+Add (create the file if it doesn't exist):
+
+```json
+{
+  "mcpServers": {
+    "twitter": {
+      "command": "twikit-mcp",
+      "env": {
+        "TWITTER_COOKIES": "/home/YOU/.config/twitter-mcp/cookies.json"
+      }
+    }
+  }
+}
+```
+
+Restart Claude Desktop.
+
+### Cursor
+
+Edit `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` (per-project):
+
+```json
+{
+  "mcpServers": {
+    "twitter": {
+      "command": "twikit-mcp",
+      "env": {
+        "TWITTER_COOKIES": "/home/YOU/.config/twitter-mcp/cookies.json"
+      }
+    }
+  }
+}
+```
+
+Cursor reloads automatically; no restart needed.
+
+### Windsurf
+
+Edit `~/.codeium/windsurf/mcp_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "twitter": {
+      "command": "twikit-mcp",
+      "env": {
+        "TWITTER_COOKIES": "/home/YOU/.config/twitter-mcp/cookies.json"
+      }
+    }
+  }
+}
+```
+
+Restart Windsurf.
+
+### Cline (VS Code extension)
+
+Open the Cline panel → ⚙️ → **MCP Servers** → **Edit MCP Settings**. Cline auto-reloads on save.
+
+```json
+{
+  "mcpServers": {
+    "twitter": {
+      "command": "twikit-mcp",
+      "env": {
+        "TWITTER_COOKIES": "/home/YOU/.config/twitter-mcp/cookies.json"
+      }
+    }
+  }
+}
+```
+
+### opencode
+
+Edit `~/.config/opencode/config.json`:
+
+```json
+{
+  "mcpServers": {
+    "twitter": {
+      "command": "twikit-mcp",
+      "env": {
+        "TWITTER_COOKIES": "/home/YOU/.config/twitter-mcp/cookies.json"
+      }
+    }
+  }
+}
+```
+
+### Any other MCP client
+
+`twikit-mcp` is a standard **stdio** MCP server. Whatever your client's config file looks like, the JSON shape is the same:
+
+```json
+{
+  "mcpServers": {
+    "twitter": {
+      "command": "twikit-mcp",
+      "env": {
+        "TWITTER_COOKIES": "/home/YOU/.config/twitter-mcp/cookies.json"
+      }
+    }
+  }
+}
+```
+
+Some clients use `mcp.servers` instead of `mcpServers`, or wrap it under a different top-level key — check your client's docs. The `command` and `env` fields are universal.
+
+## Verify
+
+In your client, ask:
+
+> Search tweets about AI
+
+The agent should call `search_tweets` and return results. If you get a permissions error, your `cookies.json` path is wrong; double-check `TWITTER_COOKIES` in the config above.
+
+## Upgrading
+
+```bash
+uv tool upgrade twikit-mcp
+```
+
+That's it — your client picks up the new binary on next launch.

--- a/docs/install.ja.md
+++ b/docs/install.ja.md
@@ -1,0 +1,171 @@
+# インストール + MCP クライアントへの登録
+
+3 ステップ。ステップ 3 でクライアントを選びます。
+
+## 1. バイナリをインストール
+
+```bash
+uv tool install twikit-mcp
+```
+
+なぜ `uv tool install`:`twikit-mcp` を独立環境(依存衝突なし)で `PATH` 上に配置、以降の起動は瞬時、アップグレードは `uv tool upgrade twikit-mcp` の一行で完結。
+
+`uv` がない場合:[1 行でインストール](https://docs.astral.sh/uv/getting-started/installation/)(macOS / Linux は curl 一発)。`pipx` / `pip` でも OK — 詳細は [README "Choose your install"](https://github.com/tangivis/twitter-mcp#choose-your-install) を参照。
+
+## 2. X の cookies を配置
+
+ブラウザで [x.com](https://x.com) にログイン → DevTools(F12)→ **Application** → **Cookies** → `https://x.com`。`ct0` と `auth_token` をコピー。
+
+```bash
+mkdir -p ~/.config/twitter-mcp
+cat > ~/.config/twitter-mcp/cookies.json <<'EOF'
+{"ct0": "...", "auth_token": "..."}
+EOF
+chmod 600 ~/.config/twitter-mcp/cookies.json
+```
+
+## 3. クライアントへの登録
+
+JSON の形(`mcpServers` ブロック)はどのクライアントでも同じ、**設定ファイルの場所**だけが違います。`/home/YOU` は自分のホームに置き換えてください。
+
+### Claude Code
+
+CLI 一発、JSON を編集不要:
+
+```bash
+claude mcp add twitter -s user \
+  -e "TWITTER_COOKIES=$HOME/.config/twitter-mcp/cookies.json" \
+  -- twikit-mcp
+```
+
+### Claude Desktop
+
+| OS | 設定ファイル |
+|---|---|
+| macOS | `~/Library/Application Support/Claude/claude_desktop_config.json` |
+| Windows | `%APPDATA%\Claude\claude_desktop_config.json` |
+| Linux | `~/.config/Claude/claude_desktop_config.json` |
+
+ファイルがなければ作成、以下を追加:
+
+```json
+{
+  "mcpServers": {
+    "twitter": {
+      "command": "twikit-mcp",
+      "env": {
+        "TWITTER_COOKIES": "/home/YOU/.config/twitter-mcp/cookies.json"
+      }
+    }
+  }
+}
+```
+
+Claude Desktop を再起動。
+
+### Cursor
+
+`~/.cursor/mcp.json`(グローバル)または `.cursor/mcp.json`(プロジェクト単位)を編集:
+
+```json
+{
+  "mcpServers": {
+    "twitter": {
+      "command": "twikit-mcp",
+      "env": {
+        "TWITTER_COOKIES": "/home/YOU/.config/twitter-mcp/cookies.json"
+      }
+    }
+  }
+}
+```
+
+Cursor は自動リロードするので再起動不要。
+
+### Windsurf
+
+`~/.codeium/windsurf/mcp_config.json` を編集:
+
+```json
+{
+  "mcpServers": {
+    "twitter": {
+      "command": "twikit-mcp",
+      "env": {
+        "TWITTER_COOKIES": "/home/YOU/.config/twitter-mcp/cookies.json"
+      }
+    }
+  }
+}
+```
+
+Windsurf を再起動。
+
+### Cline(VS Code 拡張)
+
+Cline パネル → ⚙️ → **MCP Servers** → **Edit MCP Settings** を開く。保存すると自動リロード。
+
+```json
+{
+  "mcpServers": {
+    "twitter": {
+      "command": "twikit-mcp",
+      "env": {
+        "TWITTER_COOKIES": "/home/YOU/.config/twitter-mcp/cookies.json"
+      }
+    }
+  }
+}
+```
+
+### opencode
+
+`~/.config/opencode/config.json` を編集:
+
+```json
+{
+  "mcpServers": {
+    "twitter": {
+      "command": "twikit-mcp",
+      "env": {
+        "TWITTER_COOKIES": "/home/YOU/.config/twitter-mcp/cookies.json"
+      }
+    }
+  }
+}
+```
+
+### その他の MCP クライアント
+
+`twikit-mcp` は標準的な **stdio** MCP サーバーです。クライアントの設定ファイルがどんな形でも、JSON の形は同じ:
+
+```json
+{
+  "mcpServers": {
+    "twitter": {
+      "command": "twikit-mcp",
+      "env": {
+        "TWITTER_COOKIES": "/home/YOU/.config/twitter-mcp/cookies.json"
+      }
+    }
+  }
+}
+```
+
+クライアントによっては `mcpServers` ではなく `mcp.servers` を使ったり、別のトップレベル key の中にネストすることもあります — クライアントのドキュメントを確認してください。`command` と `env` フィールドはどこでも共通です。
+
+## 動作確認
+
+クライアントで質問してみる:
+
+> AI 関連のツイートを検索して
+
+エージェントが `search_tweets` を呼び結果を返せば OK。権限エラーが出たら `cookies.json` のパスが間違っているはず — 上の JSON の `TWITTER_COOKIES` を再確認。
+
+## アップグレード
+
+```bash
+uv tool upgrade twikit-mcp
+```
+
+完了 — 次回クライアント起動時に新しいバイナリが使われます。

--- a/docs/install.zh.md
+++ b/docs/install.zh.md
@@ -1,0 +1,171 @@
+# 安装 + 注册到你的 MCP 客户端
+
+三步。第 3 步选你的客户端。
+
+## 1. 安装二进制
+
+```bash
+uv tool install twikit-mcp
+```
+
+为什么用 `uv tool install`:把 `twikit-mcp` 装在独立隔离环境里(无依赖冲突),后续启动是即时的,升级只要一句 `uv tool upgrade twikit-mcp`。
+
+没有 `uv`:[一行装好](https://docs.astral.sh/uv/getting-started/installation/)(macOS / Linux 一条 curl)。也可以用 `pipx` / `pip` — 详见 [README "Choose your install"](https://github.com/tangivis/twitter-mcp#choose-your-install)。
+
+## 2. 把 X cookies 放好
+
+浏览器登 [x.com](https://x.com) → DevTools(F12)→ **Application** → **Cookies** → `https://x.com`,复制 `ct0` 和 `auth_token` 两个值。
+
+```bash
+mkdir -p ~/.config/twitter-mcp
+cat > ~/.config/twitter-mcp/cookies.json <<'EOF'
+{"ct0": "...", "auth_token": "..."}
+EOF
+chmod 600 ~/.config/twitter-mcp/cookies.json
+```
+
+## 3. 注册到你的客户端
+
+每个客户端配置的 JSON 形状(`mcpServers` 块)都一样,只是**配置文件位置**不同。下面把 `/home/YOU` 替换成你自己的家目录。
+
+### Claude Code
+
+CLI 命令一行搞定,不用编辑 JSON:
+
+```bash
+claude mcp add twitter -s user \
+  -e "TWITTER_COOKIES=$HOME/.config/twitter-mcp/cookies.json" \
+  -- twikit-mcp
+```
+
+### Claude Desktop
+
+| 系统 | 配置文件 |
+|---|---|
+| macOS | `~/Library/Application Support/Claude/claude_desktop_config.json` |
+| Windows | `%APPDATA%\Claude\claude_desktop_config.json` |
+| Linux | `~/.config/Claude/claude_desktop_config.json` |
+
+文件不存在就创建,加进去:
+
+```json
+{
+  "mcpServers": {
+    "twitter": {
+      "command": "twikit-mcp",
+      "env": {
+        "TWITTER_COOKIES": "/home/YOU/.config/twitter-mcp/cookies.json"
+      }
+    }
+  }
+}
+```
+
+重启 Claude Desktop。
+
+### Cursor
+
+编辑 `~/.cursor/mcp.json`(全局)或 `.cursor/mcp.json`(项目级):
+
+```json
+{
+  "mcpServers": {
+    "twitter": {
+      "command": "twikit-mcp",
+      "env": {
+        "TWITTER_COOKIES": "/home/YOU/.config/twitter-mcp/cookies.json"
+      }
+    }
+  }
+}
+```
+
+Cursor 自动加载,不用重启。
+
+### Windsurf
+
+编辑 `~/.codeium/windsurf/mcp_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "twitter": {
+      "command": "twikit-mcp",
+      "env": {
+        "TWITTER_COOKIES": "/home/YOU/.config/twitter-mcp/cookies.json"
+      }
+    }
+  }
+}
+```
+
+重启 Windsurf。
+
+### Cline(VS Code 扩展)
+
+打开 Cline 面板 → ⚙️ → **MCP Servers** → **Edit MCP Settings**。保存后 Cline 自动加载。
+
+```json
+{
+  "mcpServers": {
+    "twitter": {
+      "command": "twikit-mcp",
+      "env": {
+        "TWITTER_COOKIES": "/home/YOU/.config/twitter-mcp/cookies.json"
+      }
+    }
+  }
+}
+```
+
+### opencode
+
+编辑 `~/.config/opencode/config.json`:
+
+```json
+{
+  "mcpServers": {
+    "twitter": {
+      "command": "twikit-mcp",
+      "env": {
+        "TWITTER_COOKIES": "/home/YOU/.config/twitter-mcp/cookies.json"
+      }
+    }
+  }
+}
+```
+
+### 其他任何 MCP 客户端
+
+`twikit-mcp` 是标准 **stdio** MCP server。不管你的客户端配置文件长什么样,JSON 形状都一样:
+
+```json
+{
+  "mcpServers": {
+    "twitter": {
+      "command": "twikit-mcp",
+      "env": {
+        "TWITTER_COOKIES": "/home/YOU/.config/twitter-mcp/cookies.json"
+      }
+    }
+  }
+}
+```
+
+有些客户端用 `mcp.servers` 不是 `mcpServers`,或者包在另一个顶层 key 下面 — 看客户端文档。`command` 和 `env` 字段都通用。
+
+## 验证
+
+在你的客户端里问一句:
+
+> 搜一下 AI 相关的推文
+
+agent 应该调 `search_tweets` 把结果返回。如果报权限错,八成是 `cookies.json` 路径写错了 — 检查上面 JSON 里的 `TWITTER_COOKIES`。
+
+## 升级
+
+```bash
+uv tool upgrade twikit-mcp
+```
+
+完事 — 客户端下次启动就用新二进制。

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,6 +65,7 @@ plugins:
           build: true
           nav:
             - Home: index.md
+            - Install: install.md
             - CLI mode: cli.md
             - MCP Tools API: api.md
             - Internals:
@@ -76,6 +77,7 @@ plugins:
           build: true
           nav:
             - 首页: index.md
+            - 安装: install.md
             - CLI 模式: cli.md
             - MCP 工具 API: api.md
             - 内部实现:
@@ -87,6 +89,7 @@ plugins:
           build: true
           nav:
             - ホーム: index.md
+            - インストール: install.md
             - CLI モード: cli.md
             - MCP ツール API: api.md
             - 内部実装:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "twikit-mcp"
-version = "0.1.30"
+version = "0.1.31"
 description = "Twitter/X MCP server powered by twikit — no API key needed, free forever"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_install_doc.py
+++ b/tests/test_install_doc.py
@@ -1,0 +1,102 @@
+"""Issue #92: per-client install matrix in docs/install.{en,zh,ja}.md.
+
+Sentinel: assert the install page exists per locale, carries the
+right title, has sections for the 6 documented clients, and the
+JSON config snippet parses as valid JSON.
+"""
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_INSTALL_FILES = {
+    "en": _REPO_ROOT / "docs" / "install.en.md",
+    "zh": _REPO_ROOT / "docs" / "install.zh.md",
+    "ja": _REPO_ROOT / "docs" / "install.ja.md",
+}
+# Strings each locale's title MUST contain (substring, not exact).
+_LOCALE_TITLE_HINT = {
+    "en": "Install",
+    "zh": "安装",
+    "ja": "インストール",
+}
+# Clients that must each get their own h3 section in every locale.
+_CLIENTS = [
+    "Claude Code",
+    "Claude Desktop",
+    "Cursor",
+    "Windsurf",
+    "Cline",
+    "opencode",
+]
+
+
+@pytest.mark.parametrize("locale", ["en", "zh", "ja"])
+def test_install_page_exists_per_locale(locale):
+    assert _INSTALL_FILES[locale].exists(), (
+        f"docs/install.{locale}.md missing — issue #92 requires per-locale install pages."
+    )
+
+
+@pytest.mark.parametrize("locale", ["en", "zh", "ja"])
+def test_install_page_title_carries_locale_hint(locale):
+    src = _INSTALL_FILES[locale].read_text(encoding="utf-8")
+    # The title is the first `# ` line; assert the locale's word for
+    # "install" appears in it.
+    title_line = next(
+        (line for line in src.splitlines() if line.startswith("# ")), None
+    )
+    assert title_line, f"no top-level `# ` heading in install.{locale}.md"
+    assert _LOCALE_TITLE_HINT[locale] in title_line, (
+        f"title {title_line!r} doesn't include the {locale} keyword "
+        f"{_LOCALE_TITLE_HINT[locale]!r}; check translation."
+    )
+
+
+@pytest.mark.parametrize("locale", ["en", "zh", "ja"])
+@pytest.mark.parametrize("client", _CLIENTS)
+def test_install_page_documents_each_client(locale, client):
+    src = _INSTALL_FILES[locale].read_text(encoding="utf-8")
+    # h3 + client name appears somewhere (heading or path table or JSON
+    # comment — any mention proves the section exists).
+    assert client in src, (
+        f"install.{locale}.md doesn't mention client {client!r}. "
+        f"Issue #92 requires all 6 clients per locale."
+    )
+
+
+@pytest.mark.parametrize("locale", ["en", "zh", "ja"])
+def test_install_page_uses_uv_tool_install_canonical(locale):
+    """The single canonical install command — `uv tool install
+    twikit-mcp` — must be on the page."""
+    src = _INSTALL_FILES[locale].read_text(encoding="utf-8")
+    assert "uv tool install twikit-mcp" in src, (
+        f"install.{locale}.md missing the canonical "
+        f"`uv tool install twikit-mcp` command."
+    )
+
+
+@pytest.mark.parametrize("locale", ["en", "zh", "ja"])
+def test_install_page_json_snippets_are_valid(locale):
+    """Every fenced ```json block on the page parses as valid JSON.
+    Catches silent typos that would mislead users (trailing comma /
+    unbalanced brace etc.)."""
+    src = _INSTALL_FILES[locale].read_text(encoding="utf-8")
+    blocks = re.findall(r"```json\n(.*?)\n```", src, flags=re.DOTALL)
+    assert blocks, f"install.{locale}.md has zero ```json blocks"
+    for i, block in enumerate(blocks):
+        try:
+            parsed = json.loads(block)
+        except json.JSONDecodeError as e:
+            pytest.fail(
+                f"JSON block #{i + 1} in install.{locale}.md is invalid: {e}\n"
+                f"Block:\n{block}"
+            )
+        # Sanity: every snippet should be an mcpServers config.
+        assert "mcpServers" in parsed, (
+            f"JSON block #{i + 1} in install.{locale}.md doesn't have "
+            f"`mcpServers` top-level key."
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -1913,7 +1913,7 @@ wheels = [
 
 [[package]]
 name = "twikit-mcp"
-version = "0.1.30"
+version = "0.1.31"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
closes #92

## Summary

User flagged the docs site only documents Claude Code in detail; other MCP clients (Claude Desktop / Cursor / Windsurf / Cline / opencode) get one generic JSON snippet + a parenthetical "works with these clients too." This PR closes the gap.

## What's added

New `docs/install.{en,zh,ja}.md` (i18n suffix mode) with a 3-step structure:

1. **Install**: single canonical `uv tool install twikit-mcp` command (no per-client variants).
2. **Cookies**: `~/.config/twitter-mcp/cookies.json` setup.
3. **Register**: per-client cards — each ≤ 12 lines, just config-file path + JSON snippet + restart-or-not. JSON shape is universal (`mcpServers` block); only **where** to paste it differs per client.

## Clients covered

| Client | Config |
|---|---|
| Claude Code | `claude mcp add twitter ...` CLI (no JSON) |
| Claude Desktop | OS-specific path table (mac / Win / Linux) + JSON + restart |
| Cursor | `~/.cursor/mcp.json` + JSON + auto-reload |
| Windsurf | `~/.codeium/windsurf/mcp_config.json` + JSON + restart |
| Cline (VS Code) | Settings panel → MCP Servers + JSON + auto-reload |
| opencode | `~/.config/opencode/config.json` + JSON |
| "Any other" generic | universal JSON for the long tail |

## mkdocs.yml

Adds **"Install"** between **Home** and **CLI mode** in all 3 locale navs (En / 中文 / 日本語).

## Tests

`tests/test_install_doc.py` (30 tests):
- Per-locale page exists
- Title carries locale-appropriate keyword (Install / 安装 / インストール)
- Each of 6 clients mentioned in each locale (matrix product)
- Canonical `uv tool install twikit-mcp` present
- Every ` ```json ` block parses as valid JSON with `mcpServers` top-level key

## Test plan

- [x] `pytest tests/test_install_doc.py` — **30/30 pass**.
- [x] `pytest -q --cov=twitter_mcp.server --cov-fail-under=95` — **724 pass, 100% coverage**.
- [x] `mkdocs build` clean (no broken links / nav warnings introduced).
- [x] `pyproject.toml` 0.1.30 → 0.1.31; `uv.lock` regenerated.
- [x] Tri-lingual landing pages updated with "What's new in 0.1.31" pointing at the new install page.
- [ ] Cascade post-merge: docs.yml redeploys, Install pages live at `/`, `/zh/install/`, `/ja/install/`.

## Out of scope

- Hermes / OpenClaw / niche clients — not recognized in standard MCP ecosystem.
- README's "Choose your install" section — kept for GitHub browsers; docs page is the simple-path entry for new users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZ5NXtFwvf3yybuRVSzvPY)_