### PR TITLE
feat: get_tweet_replies — fetch tweet replies/comments (closes #94)

### DIFF
--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -31,7 +31,7 @@ permissions:
 
 jobs:
   smoke:
-    name: 25 idempotent reads (live)
+    name: 26 idempotent reads (live)
     if: github.repository == 'tangivis/twitter-mcp'
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -73,7 +73,7 @@ jobs:
       - name: Install dependencies
         run: uv sync --group dev
 
-      - name: Smoke 25 idempotent reads against real X
+      - name: Smoke 26 idempotent reads against real X
         # Each block hits a different twikit code path. If X rotates a
         # GraphQL queryId, changes a field, or moves an endpoint, this
         # surfaces it within 7 days (cron) instead of when the next
@@ -110,7 +110,7 @@ jobs:
               get_trends,
               get_user_followers,
               get_lists,
-              # Issue #73: extend to all 25 idempotent reads.
+              # Issue #73: extend to all 26 idempotent reads.
               get_article_preview,
               get_bookmarks,
               get_communities_timeline,
@@ -132,6 +132,7 @@ jobs:
               search_community,
               search_community_tweet,
               search_user,
+              get_tweet_replies,
           )
 
           # Issue #73 stable target IDs (last verified 2026-05-06):
@@ -319,6 +320,13 @@ jobs:
               assert isinstance(o.get("users"), list), "missing 'users' key"
               return f"{len(o['users'])} user hits (empty OK — X gates user search)"
 
+          def v_replies(o):
+              # `get_tweet_replies` returns {"tweet_id": ..., "replies": [...],
+              # "next_cursor": ..., "count": ...}. Empty replies OK — burner
+              # may not see all comments due to X gating.
+              assert isinstance(o.get("replies"), list), "missing 'replies' key"
+              return f"{len(o['replies'])} replies (empty OK — X gates conversation visibility)"
+
           def v_article_preview(o):
               # `get_article_preview` returns a JSON object with article
               # metadata. Shape varies; only assert it's a dict.
@@ -417,24 +425,28 @@ jobs:
               # Article preview (uses an article-bearing tweet's id; if X
               # changes the article system, tolerate via T_TWEET).
               await check("get_article_preview", get_article_preview(tweet_id="2048420352397864960"), v_article_preview, tolerate_substr=T_ARTICLE_PREVIEW)
+              # Tweet replies (issue #94, 0.1.32) — TweetDetail endpoint;
+              # may return empty for X-gated burners. T_TWEET covers
+              # `Tweet not found` / `not authorized` if X drops the target.
+              await check("get_tweet_replies", get_tweet_replies(tweet_id="20"), v_replies, tolerate_substr=T_TWEET)
 
               print("\n".join(successes))
               if failures:
                   print("\n".join(failures))
-                  raise SystemExit(f"\n{len(failures)} of 25 checks failed against live X")
-              print(f"\nAll 25 reads passed against live X.")
+                  raise SystemExit(f"\n{len(failures)} of 26 checks failed against live X")
+              print(f"\nAll 26 reads passed against live X.")
 
           asyncio.run(main())
           PY
 
       # If smoke.log exists, mirror its tail to the run summary so the failure
       # is visible from the workflow page without expanding the step. Always
-      # runs (even on success) — successes show "All 25 reads passed".
+      # runs (even on success) — successes show "All 26 reads passed".
       - name: Render summary
         if: always() && hashFiles('smoke.log') != ''
         run: |
           {
-            echo "### live-smoke (25 idempotent reads)"
+            echo "### live-smoke (26 idempotent reads)"
             echo
             echo '```'
             tail -n 40 smoke.log

--- a/docs/index.en.md
+++ b/docs/index.en.md
@@ -8,11 +8,15 @@
 
 An [MCP](https://modelcontextprotocol.io/) server that lets Claude (or any MCP-compatible AI agent) interact with Twitter/X using browser cookies. The same `twikit-mcp` binary doubles as a CLI for shell scripts and debugging.
 
+## What's new in 0.1.32
+
+- **Read tweet replies** — new `get_tweet_replies(tweet_id, cursor=None)` tool fetches the comments / discussion under a tweet. Uses X's TweetDetail GraphQL via vendored twikit; one page per call with `next_cursor` for more. Returns the same compact reply shape as `get_user_tweets` / `get_timeline`. (closes #94)
+
+Upgrade with `uv tool upgrade twikit-mcp` (or `pip install --upgrade twikit-mcp`).
+
 ## What's new in 0.1.31
 
 - **Per-client install matrix in docs** — new [Install page](install.md) walks through registering `twikit-mcp` with Claude Code / Claude Desktop / Cursor / Windsurf / Cline / opencode (config file path + JSON snippet, ≤ 12 lines per client). Single canonical install command (`uv tool install twikit-mcp`); JSON shape is universal across clients. (closes #92)
-
-Upgrade with `uv tool upgrade twikit-mcp` (or `pip install --upgrade twikit-mcp`).
 
 ## What's new in 0.1.30
 

--- a/docs/index.ja.md
+++ b/docs/index.ja.md
@@ -8,11 +8,15 @@
 
 [MCP](https://modelcontextprotocol.io/) サーバー — Claude(や MCP 対応の AI エージェント)がブラウザ cookies で Twitter/X を操作できます。同じ `twikit-mcp` バイナリは CLI としてもシェルスクリプトやデバッグに使えます。
 
+## 0.1.32 の新機能
+
+- **ツイート返信の取得** — 新規 `get_tweet_replies(tweet_id, cursor=None)` ツールでツイートへのコメント / リプライを取得。vendored twikit 経由で X の TweetDetail GraphQL を使用、1 ページごとに `next_cursor` で次ページ。リプライアイテムは `get_user_tweets` / `get_timeline` と同じコンパクト形式。(closes #94)
+
+アップグレード:`uv tool upgrade twikit-mcp`(または `pip install --upgrade twikit-mcp`)。
+
 ## 0.1.31 の新機能
 
 - **クライアント別インストール手順を文書化** — 新規[インストールページ](install.md)で Claude Code / Claude Desktop / Cursor / Windsurf / Cline / opencode 6 クライアントへの登録手順を整理(クライアントあたり ≤ 12 行、設定ファイルパス + JSON スニペットのみ)。インストールコマンドは `uv tool install twikit-mcp` 統一、JSON の形はどのクライアントでも共通。(closes #92)
-
-アップグレード:`uv tool upgrade twikit-mcp`(または `pip install --upgrade twikit-mcp`)。
 
 ## 0.1.30 の新機能
 

--- a/docs/index.zh.md
+++ b/docs/index.zh.md
@@ -8,11 +8,15 @@
 
 [MCP](https://modelcontextprotocol.io/) server,让 Claude(或任何 MCP 兼容的 AI agent)用浏览器 cookies 操作 Twitter/X。同一个 `twikit-mcp` 二进制还能当 CLI 用,适合 shell 脚本和调试。
 
+## 0.1.32 新增
+
+- **读推文回复** — 新增 `get_tweet_replies(tweet_id, cursor=None)` 工具,拿一条推下面的评论 / 讨论。走 X 的 TweetDetail GraphQL 端点(vendored twikit),一次返回一页,带 `next_cursor` 翻下一页。回复条目用和 `get_user_tweets` / `get_timeline` 同款紧凑形状。(closes #94)
+
+升级:`uv tool upgrade twikit-mcp`(或 `pip install --upgrade twikit-mcp`)。
+
 ## 0.1.31 新增
 
 - **各客户端安装矩阵文档** — 新增[安装页](install.md),走过 Claude Code / Claude Desktop / Cursor / Windsurf / Cline / opencode 6 个客户端的注册步骤(每个 ≤ 12 行,只列配置文件路径 + JSON 片段)。统一安装命令(`uv tool install twikit-mcp`),JSON 形状跨客户端通用。(closes #92)
-
-升级:`uv tool upgrade twikit-mcp`(或 `pip install --upgrade twikit-mcp`)。
 
 ## 0.1.30 新增
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "twikit-mcp"
-version = "0.1.31"
+version = "0.1.32"
 description = "Twitter/X MCP server powered by twikit — no API key needed, free forever"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_replies.py
+++ b/tests/test_replies.py
@@ -1,0 +1,181 @@
+"""Issue #94: get_tweet_replies tool.
+
+Mock-only — never invokes real X. The vendored
+`Client.get_tweet_by_id` populates `tweet.replies` as a `Result[Tweet]`;
+server's `get_tweet_replies` wraps that into the standard JSON shape.
+"""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from twitter_mcp import server
+
+
+def _fake_user(screen_name="alice", name="Alice"):
+    return SimpleNamespace(screen_name=screen_name, name=name)
+
+
+def _fake_reply_tweet(
+    tid="100",
+    text="reply text",
+    user=None,
+    favorite_count=1,
+    retweet_count=0,
+    created_at="Mon Jan 01 00:00:00 +0000 2026",
+):
+    return SimpleNamespace(
+        id=tid,
+        text=text,
+        user=user or _fake_user(),
+        favorite_count=favorite_count,
+        retweet_count=retweet_count,
+        created_at=created_at,
+    )
+
+
+def _fake_tweet_with_replies(parent_id, replies, next_cursor=None):
+    """Mirror the shape `Client.get_tweet_by_id` returns: a parent tweet
+    with `.replies` set to a Result-like (iterable + .next_cursor)."""
+
+    class _FakeResult(list):
+        pass
+
+    result = _FakeResult(replies)
+    result.next_cursor = next_cursor
+    return SimpleNamespace(id=parent_id, replies=result)
+
+
+@pytest.fixture
+def fake_client(monkeypatch):
+    client = AsyncMock()
+    monkeypatch.setattr(server, "_get_client", AsyncMock(return_value=client))
+    return client
+
+
+# ── happy path ───────────────────────────────────────
+
+
+async def test_get_tweet_replies_returns_full_shape(fake_client):
+    parent = _fake_tweet_with_replies(
+        parent_id="20",
+        replies=[
+            _fake_reply_tweet(
+                tid="101",
+                text="first reply",
+                user=_fake_user("bob", "Bob"),
+                favorite_count=5,
+                retweet_count=1,
+                created_at="Tue Jan 02 00:00:00 +0000 2026",
+            ),
+            _fake_reply_tweet(
+                tid="102",
+                text="second reply",
+                user=_fake_user("carol", "Carol"),
+            ),
+        ],
+        next_cursor="cursor-abc",
+    )
+    fake_client.get_tweet_by_id = AsyncMock(return_value=parent)
+    out = json.loads(await server.get_tweet_replies("20"))
+    assert out == {
+        "tweet_id": "20",
+        "replies": [
+            {
+                "id": "101",
+                "author": "bob",
+                "text": "first reply",
+                "created_at": "Tue Jan 02 00:00:00 +0000 2026",
+                "likes": 5,
+                "retweets": 1,
+            },
+            {
+                "id": "102",
+                "author": "carol",
+                "text": "second reply",
+                "created_at": "Mon Jan 01 00:00:00 +0000 2026",
+                "likes": 1,
+                "retweets": 0,
+            },
+        ],
+        "next_cursor": "cursor-abc",
+        "count": 2,
+    }
+
+
+async def test_get_tweet_replies_handles_empty(fake_client):
+    """Tweet with no replies → shape-stable empty list."""
+    parent = _fake_tweet_with_replies(parent_id="20", replies=[], next_cursor=None)
+    fake_client.get_tweet_by_id = AsyncMock(return_value=parent)
+    out = json.loads(await server.get_tweet_replies("20"))
+    assert out["replies"] == []
+    assert out["next_cursor"] is None
+    assert out["count"] == 0
+
+
+# ── pagination ───────────────────────────────────────
+
+
+async def test_get_tweet_replies_passes_cursor_through(fake_client):
+    """`cursor` arg flows to `client.get_tweet_by_id` for pagination."""
+    parent = _fake_tweet_with_replies(parent_id="20", replies=[], next_cursor="next-2")
+    fake_client.get_tweet_by_id = AsyncMock(return_value=parent)
+
+    await server.get_tweet_replies("20", cursor="page-1")
+    fake_client.get_tweet_by_id.assert_awaited_once_with("20", cursor="page-1")
+
+
+async def test_get_tweet_replies_default_cursor_is_none(fake_client):
+    parent = _fake_tweet_with_replies(parent_id="20", replies=[])
+    fake_client.get_tweet_by_id = AsyncMock(return_value=parent)
+
+    await server.get_tweet_replies("20")
+    fake_client.get_tweet_by_id.assert_awaited_once_with("20", cursor=None)
+
+
+# ── URL extraction ──────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "url,expected_id",
+    [
+        ("12345", "12345"),
+        ("https://x.com/user/status/12345", "12345"),
+        ("https://twitter.com/user/status/67890", "67890"),
+    ],
+)
+async def test_get_tweet_replies_extracts_id_from_url(fake_client, url, expected_id):
+    parent = _fake_tweet_with_replies(parent_id=expected_id, replies=[])
+    fake_client.get_tweet_by_id = AsyncMock(return_value=parent)
+
+    out = json.loads(await server.get_tweet_replies(url))
+    assert out["tweet_id"] == expected_id
+    fake_client.get_tweet_by_id.assert_awaited_once_with(expected_id, cursor=None)
+
+
+# ── reply with quoted/in_reply_to fields propagates ──
+
+
+async def test_get_tweet_replies_reply_shape_does_not_carry_quoted_or_inreplyto(
+    fake_client,
+):
+    """Reply items use the compact shape (id/author/text/created/likes/
+    retweets only) — same shape as `get_user_tweets`/`get_timeline`.
+    Nested quote/reply-to would explode JSON; agent can call get_tweet
+    on a reply id for deeper introspection."""
+    reply = _fake_reply_tweet(tid="101")
+    parent = _fake_tweet_with_replies(parent_id="20", replies=[reply])
+    fake_client.get_tweet_by_id = AsyncMock(return_value=parent)
+
+    out = json.loads(await server.get_tweet_replies("20"))
+    item = out["replies"][0]
+    assert set(item.keys()) == {
+        "id",
+        "author",
+        "text",
+        "created_at",
+        "likes",
+        "retweets",
+    }

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -94,16 +94,18 @@ def test_tools_registered():
         "request_to_join_community",
         # new in v0.1.27 (issue #84)
         "download_tweet_video",
+        # new in v0.1.32 (issue #94)
+        "get_tweet_replies",
     }
     assert set(tools.keys()) == expected
 
 
 def test_tool_count():
-    """Exactly 58 tools are registered."""
+    """Exactly 59 tools are registered."""
     from twitter_mcp.server import mcp
 
     tools = mcp._tool_manager._tools
-    assert len(tools) == 58
+    assert len(tools) == 59
 
 
 # ── Tool Schema Tests ─────────────────────────────────

--- a/tests/test_vendor.py
+++ b/tests/test_vendor.py
@@ -186,11 +186,11 @@ def test_server_imports_from_vendor():
 
 
 def test_server_still_works():
-    """Server still loads and registers all 58 tools after vendoring."""
+    """Server still loads and registers all 59 tools after vendoring."""
     from twitter_mcp.server import mcp
 
     tools = mcp._tool_manager._tools
-    assert len(tools) == 58
+    assert len(tools) == 59
     expected = {
         "send_tweet",
         "get_tweet",
@@ -255,6 +255,8 @@ def test_server_still_works():
         "request_to_join_community",
         # new in v0.1.27 (issue #84)
         "download_tweet_video",
+        # new in v0.1.32 (issue #94)
+        "get_tweet_replies",
     }
     assert set(tools.keys()) == expected
 

--- a/twitter_mcp/server.py
+++ b/twitter_mcp/server.py
@@ -158,6 +158,48 @@ async def get_tweet(tweet_id: str) -> str:
     )
 
 
+@mcp.tool()
+async def get_tweet_replies(tweet_id: str, cursor: str | None = None) -> str:
+    """Fetch replies (comments) to a tweet (issue #94).
+
+    Uses X's TweetDetail GraphQL endpoint via vendored twikit's
+    `Client.get_tweet_by_id`, which populates `tweet.replies` as a
+    paginated `Result[Tweet]`. One page per call; pass the returned
+    `next_cursor` to fetch more.
+
+    Args:
+        tweet_id: The tweet ID (numeric string) or full URL.
+        cursor: Pagination cursor from a previous response's
+            `next_cursor`; omit for the first page.
+
+    Returns:
+        JSON with tweet_id, replies (compact list — id/author/text/
+        created_at/likes/retweets), next_cursor, count.
+    """
+    tid = _extract_tweet_id(tweet_id)
+    client = await _get_client()
+    parent = await client.get_tweet_by_id(tid, cursor=cursor)
+    replies = list(getattr(parent, "replies", []) or [])
+    return _dumps(
+        {
+            "tweet_id": tid,
+            "replies": [
+                {
+                    "id": r.id,
+                    "author": r.user.screen_name,
+                    "text": r.text,
+                    "created_at": str(r.created_at),
+                    "likes": r.favorite_count,
+                    "retweets": r.retweet_count,
+                }
+                for r in replies
+            ],
+            "next_cursor": getattr(parent.replies, "next_cursor", None),
+            "count": len(replies),
+        }
+    )
+
+
 # ── download_tweet_video helpers (issue #84) ─────────
 #
 # yt-dlp + ffmpeg are NOT bundled as Python deps. Users install them

--- a/uv.lock
+++ b/uv.lock
@@ -1913,7 +1913,7 @@ wheels = [
 
 [[package]]
 name = "twikit-mcp"
-version = "0.1.31"
+version = "0.1.32"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
closes #94

## Summary

Vendored twikit already implements TweetDetail with replies — `Client.get_tweet_by_id(tweet_id, cursor)` populates `tweet.replies` as a paginated `Result[Tweet]`. Server just needed to expose it as an MCP tool.

## New tool

`get_tweet_replies(tweet_id, cursor=None) -> str`

```json
{
  "tweet_id": "20",
  "replies": [
    {"id": "...", "author": "...", "text": "...", "created_at": "...", "likes": 0, "retweets": 0}
  ],
  "next_cursor": "...",
  "count": 10
}
```

- Each reply uses the same compact shape as `get_user_tweets` / `get_timeline`
- One page per call — agent passes returned `next_cursor` for more
- `tweet_id` accepts URL or numeric (reuses `_extract_tweet_id`)

## Tests

**8 new in `tests/test_replies.py`** (all mock-only, no real X):
- Happy path full-shape assertion
- Empty replies (shape-stable)
- Cursor passes through to client
- Cursor defaults to `None` (first page)
- URL extraction × 3 (numeric / x.com / twitter.com — parametrized)
- Compact-shape parity (no quoted/in_reply_to leakage in reply items)

## Sentinel updates

- `test_server.py` / `test_vendor.py`: tool count **58 → 59** + `get_tweet_replies` added to expected set.
- `live-smoke.yml`: `get_tweet_replies` added as the **26th idempotent read**, with `T_TWEET` tolerance for X-side gating (`Tweet not found` / `not authorized`). All `25→26` references bumped throughout the workflow file.

## Test plan

- [x] `pytest tests/test_replies.py` — **8/8 pass**.
- [x] `pytest -q --cov=twitter_mcp.server --cov-fail-under=95` — **732 pass, 100% coverage**.
- [x] `yaml.safe_load(.github/workflows/live-smoke.yml)` parses cleanly.
- [x] `pyproject.toml` 0.1.31 → 0.1.32; `uv.lock` regenerated.
- [x] Tri-lingual landings updated with "What's new in 0.1.32".
- [ ] Cascade post-merge: live-smoke 26 reads pass / tolerated; PyPI 0.1.32 ships.

## Out of scope

- **Recursive reply expansion**: each `Tweet.replies` is itself a Result; agent calls `get_tweet_replies` on a reply id to drill in.
- **`get_tweet_thread`** / `reply_to` context: separate follow-up tools.
- **Filter knobs** (top vs latest, blue-only): X gates these for non-paid; not exposing what we can't honor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZ5NXtFwvf3yybuRVSzvPY)_