### PR TITLE
fix: drop 200-char truncation + use full_text + quote-tweet preview error (closes #97)

### DIFF
--- a/docs/index.en.md
+++ b/docs/index.en.md
@@ -8,11 +8,16 @@
 
 An [MCP](https://modelcontextprotocol.io/) server that lets Claude (or any MCP-compatible AI agent) interact with Twitter/X using browser cookies. The same `twikit-mcp` binary doubles as a CLI for shell scripts and debugging.
 
+## What's new in 0.1.33
+
+- **Drop the 200-char text truncation** — `get_timeline` / `search_tweets` / `get_user_tweets` / `get_bookmarks` / `get_list_tweets` / `get_scheduled_tweets` / `get_community_tweets` / `get_communities_timeline` / `search_community_tweet` no longer cut tweet text at 200 characters. `get_tweet` and `get_tweet_replies` also switch to `Tweet.full_text`, which returns the long-form text (up to 4000 chars) for X note tweets. Compact responses are user-controlled via `count`. (closes #97)
+- **`get_article_preview` distinguishes quote tweets** — when the input is a quote tweet, the error now says "this is a quote tweet, not an article. Use get_tweet to read the quoted tweet content" instead of the generic "does not embed an article".
+
+Upgrade with `uv tool upgrade twikit-mcp` (or `pip install --upgrade twikit-mcp`).
+
 ## What's new in 0.1.32
 
 - **Read tweet replies** — new `get_tweet_replies(tweet_id, cursor=None)` tool fetches the comments / discussion under a tweet. Uses X's TweetDetail GraphQL via vendored twikit; one page per call with `next_cursor` for more. Returns the same compact reply shape as `get_user_tweets` / `get_timeline`. (closes #94)
-
-Upgrade with `uv tool upgrade twikit-mcp` (or `pip install --upgrade twikit-mcp`).
 
 ## What's new in 0.1.31
 

--- a/docs/index.ja.md
+++ b/docs/index.ja.md
@@ -8,11 +8,16 @@
 
 [MCP](https://modelcontextprotocol.io/) サーバー — Claude(や MCP 対応の AI エージェント)がブラウザ cookies で Twitter/X を操作できます。同じ `twikit-mcp` バイナリは CLI としてもシェルスクリプトやデバッグに使えます。
 
+## 0.1.33 の新機能
+
+- **200 文字の切り捨てを廃止** — `get_timeline` / `search_tweets` / `get_user_tweets` / `get_bookmarks` / `get_list_tweets` / `get_scheduled_tweets` / `get_community_tweets` / `get_communities_timeline` / `search_community_tweet` がツイート本文を 200 文字でカットしなくなりました。`get_tweet` と `get_tweet_replies` も `Tweet.full_text` を使用し、X のノートツイート(長文投稿、最大 4000 文字)も完全に取得できます。レスポンスサイズは `count` 引数で制御。(closes #97)
+- **`get_article_preview` の引用ツイート対応** — 入力が引用リツイートの場合、エラーが「これは引用ツイートで、記事ではありません。引用内容は get_tweet で読んでください」に変わり、汎用の "does not embed an article" は出なくなりました。
+
+アップグレード:`uv tool upgrade twikit-mcp`(または `pip install --upgrade twikit-mcp`)。
+
 ## 0.1.32 の新機能
 
 - **ツイート返信の取得** — 新規 `get_tweet_replies(tweet_id, cursor=None)` ツールでツイートへのコメント / リプライを取得。vendored twikit 経由で X の TweetDetail GraphQL を使用、1 ページごとに `next_cursor` で次ページ。リプライアイテムは `get_user_tweets` / `get_timeline` と同じコンパクト形式。(closes #94)
-
-アップグレード:`uv tool upgrade twikit-mcp`(または `pip install --upgrade twikit-mcp`)。
 
 ## 0.1.31 の新機能
 

--- a/docs/index.zh.md
+++ b/docs/index.zh.md
@@ -8,11 +8,16 @@
 
 [MCP](https://modelcontextprotocol.io/) server,让 Claude(或任何 MCP 兼容的 AI agent)用浏览器 cookies 操作 Twitter/X。同一个 `twikit-mcp` 二进制还能当 CLI 用,适合 shell 脚本和调试。
 
+## 0.1.33 新增
+
+- **去掉 200 字符截断** — `get_timeline` / `search_tweets` / `get_user_tweets` / `get_bookmarks` / `get_list_tweets` / `get_scheduled_tweets` / `get_community_tweets` / `get_communities_timeline` / `search_community_tweet` 不再把推文 text 截到 200 字符。`get_tweet` 和 `get_tweet_replies` 也切到 `Tweet.full_text`,X note tweet(长帖,4000 字)能完整返回。响应大小由用户的 `count` 参数控制。(closes #97)
+- **`get_article_preview` 引用推文报错优化** — 输入是 quote tweet 时,错误信息变成"这是引用推文,不是文章。用 get_tweet 读引用内容",不再扔通用的 "does not embed an article"。
+
+升级:`uv tool upgrade twikit-mcp`(或 `pip install --upgrade twikit-mcp`)。
+
 ## 0.1.32 新增
 
 - **读推文回复** — 新增 `get_tweet_replies(tweet_id, cursor=None)` 工具,拿一条推下面的评论 / 讨论。走 X 的 TweetDetail GraphQL 端点(vendored twikit),一次返回一页,带 `next_cursor` 翻下一页。回复条目用和 `get_user_tweets` / `get_timeline` 同款紧凑形状。(closes #94)
-
-升级:`uv tool upgrade twikit-mcp`(或 `pip install --upgrade twikit-mcp`)。
 
 ## 0.1.31 新增
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "twikit-mcp"
-version = "0.1.32"
+version = "0.1.33"
 description = "Twitter/X MCP server powered by twikit — no API key needed, free forever"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -484,6 +484,7 @@ async def test_tool_output_preserves_unicode_raw(monkeypatch):
     fake_tweet = SimpleNamespace(
         id="1234567890",
         text="Άρσεναλ - Σάντερλαντ: (X) 0-0 τελικό",
+        full_text="Άρσεναλ - Σάντερλαντ: (X) 0-0 τελικό",
         user=SimpleNamespace(screen_name="pathfinderSport", name="Pathfinder Sports"),
         favorite_count=7269,
         retweet_count=5473,

--- a/tests/test_replies.py
+++ b/tests/test_replies.py
@@ -21,14 +21,17 @@ def _fake_user(screen_name="alice", name="Alice"):
 def _fake_reply_tweet(
     tid="100",
     text="reply text",
+    full_text=None,
     user=None,
     favorite_count=1,
     retweet_count=0,
     created_at="Mon Jan 01 00:00:00 +0000 2026",
 ):
+    """Mirrors twikit Tweet — `full_text` falls back to `text` if not given."""
     return SimpleNamespace(
         id=tid,
         text=text,
+        full_text=full_text if full_text is not None else text,
         user=user or _fake_user(),
         favorite_count=favorite_count,
         retweet_count=retweet_count,

--- a/tests/test_text_truncation.py
+++ b/tests/test_text_truncation.py
@@ -1,0 +1,265 @@
+"""Issue #97: text truncation + full_text + quote-tweet error message bugs.
+
+Three claims to verify and fix:
+
+1. **9 list endpoints hardcode `t.text[:200]`** — silently truncates
+   tweets >200 chars. Decision (option A): drop the cap entirely;
+   `count` already controls response size.
+
+2. **`Tweet.full_text` is unused** — note tweets (X long-form, up to
+   4000 chars) get truncated to legacy 280-char `text`. Switch all
+   tweet renderings to `t.full_text`, which falls back to `text` for
+   non-note tweets so non-note behavior is unchanged.
+
+3. **`get_article_preview` misleading on quote tweets** — current
+   error "Tweet X does not embed an article" doesn't help the user
+   when the tweet is actually a quote retweet. Detect the
+   `quoted_tweet` key in the syndication response and raise a
+   targeted error pointing at `get_tweet`.
+
+All tests are mock-only (no live X / no network).
+"""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from mcp.server.fastmcp.exceptions import ToolError
+
+from twitter_mcp import server
+
+
+def _fake_user(screen_name="alice", name="Alice"):
+    return SimpleNamespace(screen_name=screen_name, name=name)
+
+
+def _fake_tweet(
+    tid="100",
+    text="hello",
+    full_text=None,
+    user=None,
+    favorite_count=1,
+    retweet_count=0,
+    created_at="Mon Jan 01 00:00:00 +0000 2026",
+):
+    """Mock Tweet with text + full_text + the other accessors get_tweet
+    reads (quote / in_reply_to / conversation_id / is_quote_status).
+
+    Real twikit `Tweet.full_text` falls back to `text` if no
+    note-tweet result; we mirror that — if `full_text` arg is None,
+    `.full_text` returns `.text`."""
+    return SimpleNamespace(
+        id=tid,
+        text=text,
+        full_text=full_text if full_text is not None else text,
+        user=user or _fake_user(),
+        favorite_count=favorite_count,
+        retweet_count=retweet_count,
+        created_at=created_at,
+        in_reply_to=None,
+        conversation_id=None,
+        is_quote_status=False,
+        quote=None,
+    )
+
+
+def _result_with_cursor(items, next_cursor=None):
+    """Mimic twikit's `Result[Tweet]` — iterable + `.next_cursor` attr.
+    Subclass list (its __iter__ is a class method, so iteration works
+    inside list comprehensions; SimpleNamespace + lambda doesn't)."""
+
+    class _R(list):
+        pass
+
+    r = _R(items)
+    r.next_cursor = next_cursor
+    return r
+
+
+@pytest.fixture
+def fake_client(monkeypatch):
+    client = AsyncMock()
+    monkeypatch.setattr(server, "_get_client", AsyncMock(return_value=client))
+    return client
+
+
+# ── Bug 1: 200-char truncation in list endpoints ─────
+
+
+_LONG_TEXT = "x" * 1000  # 5x the old 200 cap
+
+
+async def test_get_timeline_returns_full_text(fake_client):
+    fake_client.get_timeline = AsyncMock(
+        return_value=[_fake_tweet(tid="1", text=_LONG_TEXT)]
+    )
+    out = json.loads(await server.get_timeline(count=5))
+    assert out[0]["text"] == _LONG_TEXT, "get_timeline still truncates"
+
+
+async def test_search_tweets_returns_full_text(fake_client):
+    fake_client.search_tweet = AsyncMock(
+        return_value=[_fake_tweet(tid="1", text=_LONG_TEXT)]
+    )
+    out = json.loads(await server.search_tweets(query="hi", count=5))
+    assert out[0]["text"] == _LONG_TEXT, "search_tweets still truncates"
+
+
+async def test_get_user_tweets_returns_full_text(fake_client):
+    fake_client.get_user_by_screen_name = AsyncMock(
+        return_value=SimpleNamespace(id="123")
+    )
+    fake_client.get_user_tweets = AsyncMock(
+        return_value=[_fake_tweet(tid="1", text=_LONG_TEXT)]
+    )
+    out = json.loads(await server.get_user_tweets(screen_name="alice", count=5))
+    assert out[0]["text"] == _LONG_TEXT, "get_user_tweets still truncates"
+
+
+async def test_get_bookmarks_returns_full_text(fake_client):
+    fake_client.get_bookmarks = AsyncMock(
+        return_value=_result_with_cursor([_fake_tweet(tid="1", text=_LONG_TEXT)])
+    )
+    out = json.loads(await server.get_bookmarks(count=5))
+    assert out["tweets"][0]["text"] == _LONG_TEXT, "get_bookmarks still truncates"
+
+
+async def test_get_list_tweets_returns_full_text(fake_client):
+    fake_client.get_list_tweets = AsyncMock(
+        return_value=_result_with_cursor([_fake_tweet(tid="1", text=_LONG_TEXT)])
+    )
+    out = json.loads(await server.get_list_tweets(list_id="L", count=5))
+    assert out["tweets"][0]["text"] == _LONG_TEXT, "get_list_tweets still truncates"
+
+
+async def test_get_community_tweets_returns_full_text(fake_client):
+    fake_client.get_community_tweets = AsyncMock(
+        return_value=_result_with_cursor([_fake_tweet(tid="1", text=_LONG_TEXT)])
+    )
+    out = json.loads(
+        await server.get_community_tweets(community_id="C", tweet_type="Top", count=5)
+    )
+    assert out["tweets"][0]["text"] == _LONG_TEXT, (
+        "get_community_tweets still truncates"
+    )
+
+
+async def test_get_communities_timeline_returns_full_text(fake_client):
+    fake_client.get_communities_timeline = AsyncMock(
+        return_value=_result_with_cursor([_fake_tweet(tid="1", text=_LONG_TEXT)])
+    )
+    out = json.loads(await server.get_communities_timeline(count=5))
+    assert out["tweets"][0]["text"] == _LONG_TEXT, (
+        "get_communities_timeline still truncates"
+    )
+
+
+async def test_search_community_tweet_returns_full_text(fake_client):
+    fake_client.search_community_tweet = AsyncMock(
+        return_value=_result_with_cursor([_fake_tweet(tid="1", text=_LONG_TEXT)])
+    )
+    out = json.loads(
+        await server.search_community_tweet(community_id="C", query="hi", count=5)
+    )
+    assert out["tweets"][0]["text"] == _LONG_TEXT, (
+        "search_community_tweet still truncates"
+    )
+
+
+# ── Bug 2: full_text used everywhere (note tweets) ───
+
+
+_NOTE_TWEET_TEXT = "n" * 3000  # >280, exercises note-tweet fallback
+
+
+async def test_get_tweet_uses_full_text(fake_client):
+    """Note tweets (X long-form): get_tweet should pick `full_text`,
+    not legacy `text`."""
+    t = _fake_tweet(
+        tid="20", text="legacy 280 truncated...", full_text=_NOTE_TWEET_TEXT
+    )
+    fake_client.get_tweets_by_ids = AsyncMock(return_value=[t])
+    out = json.loads(await server.get_tweet("20"))
+    assert out["text"] == _NOTE_TWEET_TEXT, (
+        "get_tweet returned legacy text instead of full_text — note tweets get cut at 280"
+    )
+
+
+async def test_get_tweet_replies_uses_full_text(fake_client):
+    """Replies in get_tweet_replies should also use full_text."""
+    reply = _fake_tweet(tid="101", text="legacy short", full_text=_NOTE_TWEET_TEXT)
+
+    class _R(list):
+        pass
+
+    res = _R([reply])
+    res.next_cursor = None
+    parent = SimpleNamespace(id="20", replies=res)
+    fake_client.get_tweet_by_id = AsyncMock(return_value=parent)
+    out = json.loads(await server.get_tweet_replies("20"))
+    assert out["replies"][0]["text"] == _NOTE_TWEET_TEXT, (
+        "replies got legacy text not full_text"
+    )
+
+
+async def test_get_timeline_uses_full_text(fake_client):
+    t = _fake_tweet(tid="1", text="short legacy", full_text=_NOTE_TWEET_TEXT)
+    fake_client.get_timeline = AsyncMock(return_value=[t])
+    out = json.loads(await server.get_timeline(count=5))
+    assert out[0]["text"] == _NOTE_TWEET_TEXT
+
+
+# ── Bug 3: get_article_preview quote tweet detection ─
+
+
+def _stub_syndication(monkeypatch, payload, status_code=200):
+    response = MagicMock()
+    response.status_code = status_code
+    response.json = MagicMock(return_value=payload)
+    response.raise_for_status = MagicMock()
+    instance = MagicMock()
+    instance.get = AsyncMock(return_value=response)
+    instance.__aenter__ = AsyncMock(return_value=instance)
+    instance.__aexit__ = AsyncMock(return_value=None)
+    monkeypatch.setattr(server.httpx, "AsyncClient", MagicMock(return_value=instance))
+
+
+async def test_get_article_preview_quote_tweet_gets_targeted_error(monkeypatch):
+    """Quote tweets have `quoted_tweet` in syndication response. The
+    error should point users at `get_tweet` instead of the generic
+    'does not embed an article'."""
+    payload = {
+        "id_str": "999",
+        "user": {"screen_name": "elonmusk"},
+        "quoted_tweet": {
+            "id_str": "888",
+            "text": "the quoted content",
+            "user": {"screen_name": "jack"},
+        },
+        # no "article" key
+    }
+    _stub_syndication(monkeypatch, payload)
+
+    with pytest.raises(ToolError) as exc:
+        await server.get_article_preview("999")
+    msg = str(exc.value).lower()
+    assert "quote" in msg or "quoted" in msg, (
+        f"error should mention 'quote'; got: {exc.value!r}"
+    )
+    assert "get_tweet" in str(exc.value), (
+        f"error should suggest get_tweet; got: {exc.value!r}"
+    )
+
+
+async def test_get_article_preview_non_quote_non_article_keeps_existing_error(
+    monkeypatch,
+):
+    """Backward compat: a tweet that's neither quote nor article
+    still raises the generic error (no quote-tweet hint)."""
+    payload = {"id_str": "111", "user": {"screen_name": "alice"}}
+    _stub_syndication(monkeypatch, payload)
+
+    with pytest.raises(ToolError) as exc:
+        await server.get_article_preview("111")
+    assert "does not embed an article" in str(exc.value)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -23,6 +23,7 @@ def _fake_user(screen_name="alice", name="Alice", user_id="42"):
 def _fake_tweet(
     tid="100",
     text="hello world",
+    full_text=None,
     user=None,
     favorite_count=5,
     retweet_count=2,
@@ -32,9 +33,13 @@ def _fake_tweet(
     is_quote_status=False,
     quote=None,
 ):
+    """Mirrors twikit's `Tweet` model. `full_text` falls back to `text`
+    when not given — same fallback behavior as `Tweet.full_text` for
+    non-note tweets (issue #97)."""
     return SimpleNamespace(
         id=tid,
         text=text,
+        full_text=full_text if full_text is not None else text,
         user=user or _fake_user(),
         favorite_count=favorite_count,
         retweet_count=retweet_count,
@@ -172,7 +177,8 @@ async def test_get_tweet_parses_urls(fake_client, url, expected_id):
 # ── get_timeline ─────────────────────────────────────
 
 
-async def test_get_timeline_returns_list_with_truncated_text(fake_client):
+async def test_get_timeline_returns_list_with_full_text(fake_client):
+    """Issue #97: text is no longer truncated to 200; full text comes through."""
     long_text = "x" * 500
     fake_client.get_timeline = AsyncMock(
         return_value=[_fake_tweet(tid="1", text=long_text)]
@@ -180,7 +186,7 @@ async def test_get_timeline_returns_list_with_truncated_text(fake_client):
     out = json.loads(await server.get_timeline(count=5))
     assert len(out) == 1
     assert out[0]["id"] == "1"
-    assert len(out[0]["text"]) == 200  # truncated to 200 chars
+    assert out[0]["text"] == long_text  # full text, no truncation
 
 
 async def test_get_timeline_default_count(fake_client):
@@ -228,7 +234,7 @@ async def test_search_tweets_formats_results(fake_client):
     assert len(out) == 2
     assert out[0]["id"] == "a"
     assert out[0]["text"] == "short"
-    assert len(out[1]["text"]) == 200  # truncated
+    assert len(out[1]["text"]) == 300  # full text — issue #97 dropped 200 cap
 
 
 # ── like_tweet ───────────────────────────────────────
@@ -272,13 +278,14 @@ async def test_get_user_tweets_resolves_screen_name_then_fetches(fake_client):
     assert out[0]["text"] == "tweet one"
 
 
-async def test_get_user_tweets_truncates_long_text(fake_client):
+async def test_get_user_tweets_returns_full_text(fake_client):
+    """Issue #97: 200-char truncation removed."""
     fake_client.get_user_by_screen_name = AsyncMock(return_value=_fake_user())
     fake_client.get_user_tweets = AsyncMock(
         return_value=[_fake_tweet(tid="t", text="z" * 1000)]
     )
     out = json.loads(await server.get_user_tweets("alice"))
-    assert len(out[0]["text"]) == 200
+    assert len(out[0]["text"]) == 1000
 
 
 async def test_get_user_tweets_empty(fake_client):
@@ -903,13 +910,14 @@ async def test_get_bookmarks_returns_compact_tweet_list(fake_client):
     assert "retweets" in out["tweets"][0]
 
 
-async def test_get_bookmarks_truncates_text_to_200(fake_client):
+async def test_get_bookmarks_returns_full_text(fake_client):
+    """Issue #97: 200-char truncation removed."""
     long_text = "z" * 500
     fake_client.get_bookmarks = AsyncMock(
         return_value=_FakeTweetResult([_fake_bookmark_tweet(text=long_text)])
     )
     out = json.loads(await server.get_bookmarks())
-    assert len(out["tweets"][0]["text"]) == 200
+    assert len(out["tweets"][0]["text"]) == 500
 
 
 async def test_get_bookmarks_passes_count_and_cursor(fake_client):
@@ -1848,13 +1856,14 @@ async def test_get_list_tweets_returns_compact_tweet_list(fake_client):
     assert "retweets" in out["tweets"][0]
 
 
-async def test_get_list_tweets_truncates_text_to_200(fake_client):
+async def test_get_list_tweets_returns_full_text(fake_client):
+    """Issue #97: 200-char truncation removed."""
     long_text = "z" * 500
     fake_client.get_list_tweets = AsyncMock(
         return_value=_FakeTweetResult([_fake_tweet(text=long_text)])
     )
     out = json.loads(await server.get_list_tweets("lst-1"))
-    assert len(out["tweets"][0]["text"]) == 200
+    assert len(out["tweets"][0]["text"]) == 500
 
 
 async def test_get_list_tweets_passes_cursor(fake_client):
@@ -2239,10 +2248,12 @@ def _fake_scheduled_tweet(
     execute_at=9999999999,
     state="Scheduled",
     media=None,
+    full_text=None,
 ):
     return SimpleNamespace(
         id=tweet_id,
         text=text,
+        full_text=full_text if full_text is not None else text,
         execute_at=execute_at,
         state=state,
         media=media or [],
@@ -2341,12 +2352,13 @@ async def test_get_scheduled_tweets_returns_empty_list(fake_client):
     assert out["scheduled_tweets"] == []
 
 
-async def test_get_scheduled_tweets_truncates_text_to_200(fake_client):
+async def test_get_scheduled_tweets_returns_full_text(fake_client):
+    """Issue #97: 200-char truncation removed."""
     long_text = "x" * 300
     tweets = [_fake_scheduled_tweet("s1", long_text)]
     fake_client.get_scheduled_tweets = AsyncMock(return_value=tweets)
     out = json.loads(await server.get_scheduled_tweets())
-    assert len(out["scheduled_tweets"][0]["text"]) == 200
+    assert len(out["scheduled_tweets"][0]["text"]) == 300
 
 
 async def test_get_scheduled_tweets_includes_media_count(fake_client):
@@ -2354,6 +2366,7 @@ async def test_get_scheduled_tweets_includes_media_count(fake_client):
     tweet = SimpleNamespace(
         id="s1",
         text="with media",
+        full_text="with media",
         execute_at=9000000001,
         state="Scheduled",
         media=media,
@@ -2789,13 +2802,14 @@ async def test_get_community_tweets_passes_cursor(fake_client):
     fake_client.get_community_tweets.assert_awaited_once_with("comm-1", "Top", 5, "pg2")
 
 
-async def test_get_community_tweets_truncates_text_to_200(fake_client):
+async def test_get_community_tweets_returns_full_text(fake_client):
+    """Issue #97: 200-char truncation removed."""
     long_text = "z" * 500
     fake_client.get_community_tweets = AsyncMock(
         return_value=_FakeTweetResult([_fake_tweet(text=long_text)])
     )
     out = json.loads(await server.get_community_tweets("comm-1", "Latest"))
-    assert len(out["tweets"][0]["text"]) == 200
+    assert len(out["tweets"][0]["text"]) == 500
 
 
 async def test_get_community_tweets_rejects_invalid_tweet_type(fake_client):

--- a/twitter_mcp/server.py
+++ b/twitter_mcp/server.py
@@ -144,7 +144,7 @@ async def get_tweet(tweet_id: str) -> str:
             "id": t.id,
             "author": t.user.screen_name,
             "author_name": t.user.name,
-            "text": t.text,
+            "text": t.full_text,
             "created_at": str(t.created_at),
             "likes": t.favorite_count,
             "retweets": t.retweet_count,
@@ -187,7 +187,7 @@ async def get_tweet_replies(tweet_id: str, cursor: str | None = None) -> str:
                 {
                     "id": r.id,
                     "author": r.user.screen_name,
-                    "text": r.text,
+                    "text": r.full_text,
                     "created_at": str(r.created_at),
                     "likes": r.favorite_count,
                     "retweets": r.retweet_count,
@@ -377,7 +377,7 @@ async def get_timeline(count: int = 20) -> str:
             {
                 "id": t.id,
                 "author": t.user.screen_name,
-                "text": t.text[:200],
+                "text": t.full_text,
                 "likes": t.favorite_count,
                 "retweets": t.retweet_count,
             }
@@ -402,7 +402,7 @@ async def search_tweets(query: str, count: int = 20, product: str = "Latest") ->
             {
                 "id": t.id,
                 "author": t.user.screen_name,
-                "text": t.text[:200],
+                "text": t.full_text,
                 "likes": t.favorite_count,
                 "retweets": t.retweet_count,
             }
@@ -450,7 +450,7 @@ async def get_user_tweets(screen_name: str, count: int = 20) -> str:
         result.append(
             {
                 "id": t.id,
-                "text": t.text[:200],
+                "text": t.full_text,
                 "created_at": str(t.created_at),
                 "likes": t.favorite_count,
                 "retweets": t.retweet_count,
@@ -804,7 +804,7 @@ async def get_bookmarks(count: int = 20, cursor: str | None = None) -> str:
         {
             "id": t.id,
             "author": t.user.screen_name,
-            "text": t.text[:200],
+            "text": t.full_text,
             "likes": t.favorite_count,
             "retweets": t.retweet_count,
         }
@@ -979,6 +979,14 @@ async def get_article_preview(tweet_id: str) -> str:
     data = resp.json()
     article = data.get("article")
     if not article:
+        # X's syndication response carries `quoted_tweet` for quote
+        # retweets — distinguish that case so the user gets actionable
+        # guidance instead of "no article" (issue #97).
+        if data.get("quoted_tweet"):
+            raise ToolError(
+                f"Tweet {tweet_id} is a quote tweet, not an article. "
+                f"Use get_tweet to read the quoted tweet content."
+            )
         raise ToolError(f"Tweet {tweet_id} does not embed an article.")
     cover = article.get("cover_media", {}).get("media_info", {}).get("original_img_url")
     return _dumps(
@@ -1484,7 +1492,7 @@ async def get_list_tweets(
         {
             "id": t.id,
             "author": t.user.screen_name,
-            "text": t.text[:200],
+            "text": t.full_text,
             "likes": t.favorite_count,
             "retweets": t.retweet_count,
         }
@@ -1725,7 +1733,7 @@ async def get_scheduled_tweets() -> str:
     result = [
         {
             "id": t.id,
-            "text": t.text[:200],
+            "text": t.full_text,
             "scheduled_at": t.execute_at,
             "state": t.state,
             "media_count": len(t.media),
@@ -1916,7 +1924,7 @@ async def get_community_tweets(
         {
             "id": t.id,
             "author": t.user.screen_name,
-            "text": t.text[:200],
+            "text": t.full_text,
             "likes": t.favorite_count,
             "retweets": t.retweet_count,
         }
@@ -1954,7 +1962,7 @@ async def get_communities_timeline(count: int = 20, cursor: str | None = None) -
         {
             "id": t.id,
             "author": t.user.screen_name,
-            "text": t.text[:200],
+            "text": t.full_text,
             "likes": t.favorite_count,
             "retweets": t.retweet_count,
         }
@@ -2077,7 +2085,7 @@ async def search_community_tweet(
         {
             "id": t.id,
             "author": t.user.screen_name,
-            "text": t.text[:200],
+            "text": t.full_text,
             "likes": t.favorite_count,
             "retweets": t.retweet_count,
         }

--- a/uv.lock
+++ b/uv.lock
@@ -1913,7 +1913,7 @@ wheels = [
 
 [[package]]
 name = "twikit-mcp"
-version = "0.1.32"
+version = "0.1.33"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
closes #97

## Three bugs all confirmed

### 1. Hardcoded 200-char text truncation (9 endpoints)

`get_timeline` / `search_tweets` / `get_user_tweets` / `get_bookmarks` / `get_list_tweets` / `get_scheduled_tweets` / `get_community_tweets` / `get_communities_timeline` / `search_community_tweet` all did `t.text[:200]`. Cut ~30% of normal tweets. **Fix**: drop the cap entirely; `count` already controls response size.

### 2. `Tweet.full_text` unused → note tweets truncated

twikit's `Tweet.full_text` returns up to 4000 chars for note tweets (X long-form posts), falling back to `Tweet.text` for normal tweets. We were using `t.text` everywhere, so note tweets were silently cut at 280 chars. **Fix**: switch all single + list + reply renderings to `t.full_text`. No change for non-note tweets (same fallback).

### 3. `get_article_preview` misleading error on quote tweets

When the input was a quote tweet, the syndication response has a `quoted_tweet` key but no `article` key — we raised the generic "does not embed an article" with no actionable hint. **Fix**: detect `quoted_tweet`, raise a targeted "this is a quote tweet, use `get_tweet` to read the quoted content" instead.

## Tests

**+13 in `tests/test_text_truncation.py`** (mock-only):
- 8 `*_returns_full_text` assertions per affected list endpoint
- 3 `*_uses_full_text` assertions for note-tweet propagation
- 1 quote-tweet → targeted error
- 1 non-quote non-article → keeps generic error (regression guard)

**Updated existing fakes** to mirror twikit's `Tweet.full_text` attribute (falls back to `text` if not given):
- `tests/test_tools.py` `_fake_tweet` + `_fake_scheduled_tweet`
- `tests/test_replies.py` `_fake_reply_tweet`
- `tests/test_cli.py` inline SimpleNamespace

**Renamed 5 explicit `*_truncates_text_to_200` tests** → `*_returns_full_text` with length assertions matching the new no-truncation behavior. Those tests documented the bug; now they document the fix.

## Test plan

- [x] `pytest -q --cov=twitter_mcp.server --cov-fail-under=95` — **746 pass, 100% coverage**.
- [x] `pyproject.toml` 0.1.32 → 0.1.33; `uv.lock` regenerated.
- [x] Tri-lingual landings updated with "What's new in 0.1.33".
- [ ] Cascade post-merge: live-smoke 26 reads still pass; 0.1.33 ships to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZ5NXtFwvf3yybuRVSzvPY)_