### PR TITLE
docs: add OpenClaw MCP setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,34 @@ Add to your MCP client config (e.g. `mcp.json`, `settings.json`):
 
 > Works with: Claude Code, Claude Desktop, Cursor, Windsurf, opencode, Cline, etc.
 
+#### OpenClaw
+
+OpenClaw can save `twikit-mcp` as an outbound MCP server for OpenClaw-managed agent runs. Keep the cookie file outside project repositories.
+
+```bash
+openclaw mcp add twitter \
+  --command twikit-mcp \
+  --env "TWITTER_COOKIES=$HOME/.config/twitter-mcp/cookies.json"
+
+openclaw mcp doctor twitter --probe
+```
+
+For read-only workflows, narrow the exposed tools before an agent run:
+
+```bash
+openclaw mcp tools twitter \
+  --include 'get_tweet,search_tweets,get_user_info,get_user_tweets,get_tweet_replies,get_trends'
+```
+
+If an OpenClaw workflow also needs the TweetClaw plugin's API-backed X/Twitter jobs, install it separately:
+
+```bash
+openclaw plugins install npm:@xquik/tweetclaw@1.6.31
+openclaw plugins inspect tweetclaw --runtime --json
+```
+
+Keep `twikit-mcp` responsible for cookie-backed MCP actions. Use TweetClaw for separate approval-reviewed workflows such as follower export, search tweet replies, media workflows, DMs, monitors, webhooks, giveaway draws, and post or reply jobs. Keep cookie paths and API keys in MCP or OpenClaw config, not prompts, docs, logs, or issue comments.
+
 That's it. Start talking:
 
 ```
@@ -295,7 +323,7 @@ claude mcp add twitter -s user ^
 
 ### Documentation
 
-- **[Technical Guide](docs/TECHNICAL.md)** — Architecture, MCP internals, configuration details
+- **[Technical Guide](docs/TECHNICAL.en.md)** - Architecture, MCP internals, configuration details
 - **[Contributing](CONTRIBUTING.md)** — Testing, CI/CD, how to add new tools
 
 ---
@@ -542,7 +570,7 @@ claude mcp add twitter -s user ^
 
 ### 文档
 
-- **[技术文档](docs/TECHNICAL.md)** — 架构、MCP 原理、配置详解、跨机器部署
+- **[技术文档](docs/TECHNICAL.zh.md)** - 架构、MCP 原理、配置详解、跨机器部署
 - **[贡献指南](CONTRIBUTING.md)** — 测试、CI/CD、如何添加新工具
 
 ---
@@ -789,7 +817,7 @@ claude mcp add twitter -s user ^
 
 ### ドキュメント
 
-- **[技術ドキュメント](docs/TECHNICAL.md)** — アーキテクチャ、MCP の仕組み、設定詳細
+- **[技術ドキュメント](docs/TECHNICAL.ja.md)** - アーキテクチャ、MCP の仕組み、設定詳細
 - **[コントリビューションガイド](CONTRIBUTING.md)** — テスト、CI/CD、新しいツールの追加方法
 
 ---

--- a/docs/install.en.md
+++ b/docs/install.en.md
@@ -154,6 +154,34 @@ Edit `~/.config/opencode/config.json`:
 
 Some clients use `mcp.servers` instead of `mcpServers`, or wrap it under a different top-level key — check your client's docs. The `command` and `env` fields are universal.
 
+### OpenClaw
+
+OpenClaw can save `twikit-mcp` as an outbound MCP server for OpenClaw-managed agent runs:
+
+```bash
+openclaw mcp add twitter \
+  --command twikit-mcp \
+  --env "TWITTER_COOKIES=$HOME/.config/twitter-mcp/cookies.json"
+
+openclaw mcp doctor twitter --probe
+```
+
+Use a tool filter for read-only workflows:
+
+```bash
+openclaw mcp tools twitter \
+  --include 'get_tweet,search_tweets,get_user_info,get_user_tweets,get_tweet_replies,get_trends'
+```
+
+If the same OpenClaw workflow also needs API-backed TweetClaw jobs, install the TweetClaw plugin separately:
+
+```bash
+openclaw plugins install npm:@xquik/tweetclaw@1.6.31
+openclaw plugins inspect tweetclaw --runtime --json
+```
+
+Keep `twikit-mcp` responsible for cookie-backed MCP actions. Use TweetClaw for separate approval-reviewed workflows such as follower export, search tweet replies, media workflows, DMs, monitors, webhooks, giveaway draws, and post or reply jobs. Keep cookie paths and API keys in MCP or OpenClaw config, not prompts, docs, logs, or issue comments.
+
 ## Verify
 
 In your client, ask:


### PR DESCRIPTION
## Summary

Adds OpenClaw setup docs for saving `twikit-mcp` as an outbound MCP server, probing it, and narrowing exposed tools for read-only agent runs.

Also fixes the README technical-guide links so each localized section points at the matching localized docs file.

## Test plan

- [x] `git diff --check`
- [x] `npx --yes markdown-link-check README.md docs/install.en.md --quiet`
- [x] `uv run --group dev ruff format --check . && uv run --group dev ruff check .`
- [ ] `uv run --group dev pytest -q` - local Python 3.14 reports existing `tests/test_human_cards.py::test_card_width_uses_clamped_terminal` terminal-width failure. This docs change does not touch server formatting code.
- [ ] `uv run --group docs mkdocs build --strict` - strict docs build reports existing missing docs nav targets such as `api.md`. This change does not touch `mkdocs.yml`.

## Spec / SDD checklist

- [ ] **New / changed MCP tool?** Not applicable.
- [ ] **Test fixture changed?** Not applicable.
- [ ] **Vendor-tree patch?** Not applicable.
- [ ] **New live-smoke target?** Not applicable.
- [ ] **Tool count changed?** Not applicable.

## Closes / refs

Refs OpenClaw MCP docs: https://docs.openclaw.ai/cli/mcp
